### PR TITLE
Minor opcode updates

### DIFF
--- a/docs/ref/opcodes.md
+++ b/docs/ref/opcodes.md
@@ -376,7 +376,7 @@ Conventions used in the Operator Table
 * max_arg_strlen: the length of the longest arg atom, in bytes
 * result: the return value of the function
 
-All opcodes below accept arguments as a [flat list](ref-opcodes#definitions).
+All opcodes below accept arguments as a [flat list](opcodes#definitions).
 
 keyword|opcode|impl|funcall|args|return|preconditions|cost|Allocations
 -------|------|-------------|---|---|---|---|---|---

--- a/docs/ref/opcodes.md
+++ b/docs/ref/opcodes.md
@@ -398,8 +398,8 @@ point_add|0x12|op_point_add|(point_add P1 P2 ...)|>=0|Sum any number, N, of G1 E
 pubkey_for_exp|0x13|op_pubkey_for_exp|(pubkey_for_exp E)|1|Get pubkey for E|E is an atom|900|Atom(96)
 concat|0x14|op_concat|(concat A B ...)|>=0|Concatenate args|2 * (len(A) + len(B) + ...)| Atom(map(sum, arg_lens))
 sha256tree|0x15|op_sha256tree|(sha256tree L)|1|Recursive sha256 of all leaf nodes of L|| (len_of_all_atoms*10) + (Number of CLVM Objects * 10) TODO: Check|Atom(32)
-`>`|0x16|op_gr|(> A B)|2|if A > B then 1 else nil. Int conversion via Python's [int.from_bytes](https://docs.python.org/3/library/stdtypes.html#int.from_bytes)|A and B are atoms|<p style="color:red">10 * max(A,B)</p>|None
-`>s`|0x17|op_gr_bytes|(>s A B)|2|Unsigned greater than|A and B are atoms|<p style="color:red">max(A,B)</p>|None
+`>`|0x16|op_gr|(> A B)|2|if A > B then 1 else nil. Int conversion via Python's [int.from_bytes](https://docs.python.org/3/library/stdtypes.html#int.from_bytes)|A and B are atoms|<p style={{ color: 'red' }}>10 * max(A,B)</p>|None
+`>s`|0x17|op_gr_bytes|(>s A B)|2|Unsigned greater than|A and B are atoms|<p style={{ color: 'red' }}>max(A,B)</p>|None
 logand|0x18|op_logand|(logand A B ...)|>=0|Bitwise AND of args|All args are atoms|max_arg_strlen * 2|Atom(max(arg_lens))
 logior|0x19|op_logior|(logior A B ...)|>=0|Bitwise OR of args|All args are atoms|max_arg_strlen * 2|Atom(max(arg_lens))
 logxor|0x1a|op_logxor|(logxor A B)|2|Bitwise XOR of args. The bit is 1 if that bit is 1 in an odd number of the arguments|All args are atoms|max_arg_strlen * 2|Atom(max(arg_lens))


### PR DESCRIPTION
- Updated opcodes section in /doc2 to contain explanations of Announcements
- Updated /ref/opcodes to contain an explanation of the "(not" operator"
- Updated conditions section at the bottom of /ref/opcodes to reflect current list of opcodes

Still need to update /doc2 to explain the current time opcodes (ASSERT_RELATIVE_TIME_EXCEEDS and ASSERT_TIME_EXCEEDS) and also ASSERT_FEE but I don't know enough about those to write explanations for them.