### PR TITLE
Added support for syntax highlighting (and bumped dependencies)

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -32,13 +32,13 @@ When interpreting atoms as integers, it's important to remember that they are si
 
 Cons boxes are represented as a parentheses with two elements separated by a `.`.
 For example:
-```
+```chialisp
 (200 . "hello")
 
 ("hello" . ("world" . "!!!"))
 ```
 Are legal cons boxes, but the following is not.
-```
+```chialisp
 (200 . 300 . 400)
 ```
 A cons box always has two elements.
@@ -49,17 +49,17 @@ However, we can chain cons boxes together to construct lists.
 Lists are enclosed by parentheses and each entry in the list is single spaced with no period between values.
 Lists are much more commonly used than cons boxes as they are more versatile.
 
-```
+```chialisp
 (200 300 "hello" "world")
 ```
 You can also nest lists.
-```
+```chialisp
 ("hello" ("nested" "list") ("world"))
 ```
 
 Remember a list is a representation of consecutive cons boxes terminated in a null atom `()`.
 The following expressions are equal:
-```
+```chialisp
 (200 . (300 . (400 . ())))
 
 (200 300 400)
@@ -69,7 +69,7 @@ The following expressions are equal:
 
 To interpret an atom as a value, rather than a program, it needs to be quoted with `q`. Quoted values form a cons box where the first item is the `q` operator.
 For example, this program is just the value `100`:
-```
+```chialisp
 (q . 100)
 ```
 
@@ -91,14 +91,14 @@ Programs are a subset of lists which can be evaluated using CLVM. **A program is
 
 Rule 2 is why literal values and non-program lists *must* be quoted using `q . `.
 
-```lisp
+```chialisp
 $ brun '(q . (80 90 100))'
 (80 90 100)
 ```
 
 And now that we know we can have programs inside programs we can create programs such as:
 
-```lisp
+```chialisp
 $ brun '(i (= (q . 50) (q . 50)) (+ (q . 40) (q . 30)) (q . 20))' '()'
 70
 ```
@@ -112,28 +112,28 @@ It is recommended that you create your programs in an editor with brackets match
 
 `f` returns the first element in a passed list.
 
-```lisp
+```chialisp
 $ brun '(f (q . (80 90 100)))'
 80
 ```
 
 `r` returns every element in a list except for the first.
 
-```lisp
+```chialisp
 $ brun '(r (q . (80 90 100)))'
 (90 100)
 ```
 
 `c` prepends an element to a list
 
-```lisp
+```chialisp
 $ brun '(c (q . 70) (q . (80 90 100)))'
 (70 80 90 100)
 ```
 
 And we can use combinations of these to access or replace any element we want from a list:
 
-```lisp
+```chialisp
 $ brun '(c (q . 100) (r (q . (60 110 120))))'
 (100 110 120)
 
@@ -147,7 +147,7 @@ There are no support for floating point numbers in CLVM, only integers. There is
 
 The math operators are `+`, `-`, `*`, and `/`.
 
-```lisp
+```chialisp
 $ brun '(- (q . 6) (q . 5))'
 1
 
@@ -163,7 +163,7 @@ $ brun '(/ (q . 20) (q . 11))'
 
 *Note that `/` returns the* ***floored*** *quotient. CLVM is also different from most languages in that it floors to negative infinity rather than zero.  This can create some unexpected results when trying to divide negative numbers.*
 
-```lisp
+```chialisp
 brun '(/ (q . 3) (q . 2))'
 1
 
@@ -183,7 +183,7 @@ This is because many operators can take a variable number of parameters.
 For non-commutative operations, `(- 100 30 20 5)` is equivalent to `(- 100 (+ 30 20 5))`.
 Similarly, `(/ 120 5 4 2)` is equivalent to `(/ 120 (* 5 4 2))`.
 
-```lisp
+```chialisp
 $ brun '(- (q . 5) (q . 7))'
 -2
 
@@ -194,14 +194,14 @@ $ brun '(+ (q . 3) (q . -8))'
 
 To use hexadecimal numbers, simply prefix them with `0x`.
 
-```lisp
+```chialisp
 $ brun '(+ (q . 0x000a) (q . 0x000b))'
 21
 ```
 
 The final mathematical operator is equal which acts similarly to == in other languages.
 
-```lisp
+```chialisp
 $ brun '(= (q . 5) (q . 6))'
 ()
 
@@ -216,7 +216,7 @@ As you can see above this language interprets some data as boolean values.
 In this language an empty list `()` evaluate to `False`.
 Any other value evaluates to `True`, though internally `True` is represented with `1`.
 
-```lisp
+```chialisp
 $ brun '(= (q . 100) (q . 90))'
 ()
 
@@ -226,7 +226,7 @@ $ brun '(= (q . 100) (q . 100))'
 
 The exception to this rule is `0` because `0` is  exactly the same as `()`.
 
-```lisp
+```chialisp
 $ brun '(= (q . 0) ())'
 1
 
@@ -238,7 +238,7 @@ $ brun '(+ (q . 70) ())'
 
 The `i` operator takes the form `(i A B C)` and acts as an if-statement that
 evaluates to `B` if `A` is True and `C` otherwise.
-```lisp
+```chialisp
 $ brun '(i (q . 0) (q . 70) (q . 80))'
 80
 
@@ -248,7 +248,7 @@ $ brun '(i (q . 1) (q . 70) (q . 80))'
 $ brun '(i (q . 12) (q . 70) (q . 80))'
 70
 
-$ brun '(i (q . ()) (q . 70) (q . 80))'
+$ brun '(i () (q . 70) (q . 80))'
 80
 ```
 
@@ -256,7 +256,7 @@ Note that both `B` and `C` are evaluated eagerly, just like all subexpressions.
 To defer evaluation until after the condition, `B` and `C` must be quoted (with
 `q`), and then evaluated with `(a)`.
 
-```lisp
+```chialisp
 $ brun '(a (i (q . 0) (q . (x (q . 1337) )) (q . 1)) ())'
 ```
 
@@ -272,7 +272,7 @@ This means that we need to be able to pass some information to the puzzle.
 A solution is a list of values passed to the puzzle.
 The solution can be referenced with `1`.
 
-```lisp
+```chialisp
 $ brun '1' '("this" "is the" "solution")'
 ("this" "is the" "solution")
 
@@ -285,7 +285,7 @@ $ brun '(r 1)' '(80 90 100 110)'
 
 And remember lists can be nested too.
 
-```lisp
+```chialisp
 $ brun '(f (f (r 1)))' '((70 80) (90 100) (110 120))'
 90
 
@@ -295,7 +295,7 @@ $ brun '(f (f (r 1)))' '((70 80) ((91 92 93 94 95) 100) (110 120))'
 
 These environment variables can be used in combination with all other operators.
 
-```lisp
+```chialisp
 $ brun '(+ (f 1) (q . 5))' '(10)'
 15
 
@@ -305,7 +305,7 @@ $ brun '(* (f 1) (f 1))' '(10)'
 
 This program checks that the second variable is equal to the square of the first variable.
 
-```lisp
+```chialisp
 $ brun '(= (f (r 1)) (* (f 1) (f 1)))' '(5 25)'
 1
 
@@ -317,7 +317,7 @@ $ brun '(= (f (r 1)) (* (f 1) (f 1)))' '(5 30)'
 
 In the above examples we only used `1` which access the root of the tree and returns the entire solution list.
 
-```lisp
+```chialisp
 $ brun '1' '("example" "data" "for" "test")'
 ("example" "data" "for" "test")
 ```
@@ -326,7 +326,7 @@ However, every unquoted integer in the lower level language refers to a part of 
 
 You can imagine a binary tree of `f` and `r`, where each node is numbered.
 
-```lisp
+```chialisp
 $ brun '2' '("example" "data" "for" "test")'
 "example"
 
@@ -339,7 +339,7 @@ $ brun '5' '("example" "data" "for" "test")'
 
 And this is designed to work when there are lists inside lists too.
 
-```lisp
+```chialisp
 $ brun '4' '(("deeper" "example") "data" "for" "test")'
 "deeper"
 

--- a/docs/coin_lifecycle.md
+++ b/docs/coin_lifecycle.md
@@ -9,7 +9,7 @@ You should now understand how to create Chialisp puzzles that lock up coins with
 
 Chia's model of how coins are stored is called the **coin set** model and is closely modelled after Bitcoin's UTXO model.  The idea is simple, every full node holds onto a database of **coin records**:
 
-```
+```python
 class Coin:
   parent_coin_info: bytes32
   puzzle_hash: bytes32
@@ -19,8 +19,8 @@ class CoinRecord:
   coin: Coin
   confirmed_block_index: uint32
   spent_block_index: uint32
-  spent: bool
-  coinbase: bool
+  spent: boolean
+  coinbase: boolean
   timestamp: uint64
 ```
 *Note that the `Coin` object is part of the blockchain format and cannot be changed, while the `CoinRecord` object is part of the full node and can be modified by alternative implementations*
@@ -51,7 +51,7 @@ _Fun fact: The genesis challenge is the hash of a bitcoin block around the time 
 
 Notice that the `parent_coin_info` for both is a little strange.  Because they are created out of thin air, the coins are assigned a special value as their parent coin: one half of the "genesis challenge", some filler zeroes, and the index of the block they are farmed in.
 
-```
+```python
 pool_parent_id = bytes32(genesis_challenge[:16] + block_height.to_bytes(16, "big"))
 farmer_parent_id = bytes32(genesis_challenge[16:] + block_height.to_bytes(16, "big"))
 ```
@@ -62,7 +62,7 @@ This information is usually not very relevant, but it is used.  For example, in 
 
 Alright, so you've received some XCH and you want to deploy your first smart contract.  To do that, you're first going to have to create a **spend bundle**.  This is sometimes referred to colloquially as a "transaction". A spend bundle is a simple construct.  It is an object that contains exactly two things: a list of coin spends and an aggregated signature.
 
-```
+```python
 class SpendBundle:
   coin_solutions: List[CoinSpend]
   aggregated_signature: G2Element
@@ -70,7 +70,7 @@ class SpendBundle:
 
 A **coin spend** contains exactly three things: The coin you are trying to spend (parent_coin_info, amount, puzzle_hash), the puzzle reveal (needs to tree hash to the puzzle hash), and the solution.
 
-```
+```python
 class CoinSolution:
   coin: Coin
   puzzle_reveal: SerializedProgram

--- a/docs/coins_spends_and_wallets.md
+++ b/docs/coins_spends_and_wallets.md
@@ -18,7 +18,7 @@ A coin's ID is constructed from 3 pieces of information.
 
 To construct a coin ID simply take the hash of these 3 pieces of information concatenated in order.
 
-```lisp
+```
 coinID == sha256(parent_ID + puzzlehash + amount)
 ```
 
@@ -60,7 +60,7 @@ By the end of the next section of the guide, hopefully it should be clear.
 So far in [part 1](/docs/) we have covered ChiaLisp programs that will evaluate to some result.
 Remember the first part represents a puzzle which is committed to locking up a coin, and the second part is a solution anybody can submit:
 
-```lisp
+```chialisp
 $ brun '(+ 2 5)' '(40 50)'
 90
 
@@ -96,7 +96,7 @@ Here is the complete list of conditions along with their format and behaviour.
 
 Conditions are returned as a list of lists in the form:
 
-```lisp
+```chialisp
 ((51 0xabcd1234 200) (50 0x1234abcd) (53 0xdeadbeef))
 ```
 
@@ -112,7 +112,7 @@ To implement this we would have the hash of the password committed into the puzz
 For the following example the password is "hello" which has the hash value 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824.
 The implementation for the above coin would be thus:
 
-```lisp
+```chialisp
 (i (= (sha256 2) (q . 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824)) (c (q . 51) (c 5 (c (q . 100) ()))) (q . "wrong password"))
 ```
 
@@ -127,7 +127,7 @@ Remember, anybody can attempt to spend this coin as long as they know the coin's
 
 Let's test it out using clvm_tools.
 
-```lisp
+```chialisp
 $ brun '(i (= (sha256 2) (q . 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824)) (c (c (q . 51) (c 5 (c (q . 100) ()))) (q ())) (q . "wrong password"))' '("let_me_in" 0xdeadbeef)'
 "wrong password"
 
@@ -149,13 +149,13 @@ The reason for this is explained in [part 3](/docs/deeper_into_clvm/). For now d
 
 Here is our completed password protected coin:
 
-```lisp
+```chialisp
 '(a (i (= (sha256 2) (q . 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824)) (q . (c (c (q . 51) (c 5 (c (q . 100) ()))) ())) (q . (x (q . "wrong password")))) 1)'
 ```
 
 Let's test it out using clvm_tools:
 
-```lisp
+```chialisp
 $ brun '(a (i (= (sha256 2) (q . 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824)) (q . (c (c (q . 51) (c 5 (c (q . 100) ()))) ())) (q . (x (q . "wrong password")))) 1)' '("let_me_in" 0xdeadbeef)'
 FAIL: clvm raise ("wrong password")
 
@@ -170,13 +170,13 @@ Another way of phrasing this is "how much control over the output should the sol
 
 Suppose we lock a coin up using the following puzzle:
 
-```lisp
+```chialisp
 (q . ((51 0x365bdd80582fcc2e4868076ab9f24b482a1f83f6d88fd795c362c43544380e7a 100)))
 ```
 
 Regardless of what solution is passed this puzzle will *always* return instructions to create a new coin with the puzzlehash 0x365bdd80582fcc2e4868076ab9f24b482a1f83f6d88fd795c362c43544380e7a and the amount 100.
 
-```lisp
+```chialisp
 $ brun '(q . ((51 0x365bdd80582fcc2e4868076ab9f24b482a1f83f6d88fd795c362c43544380e7a 100)))' '(80 90 "hello")'
 ((51 0x365bdd80582fcc2e4868076ab9f24b482a1f83f6d88fd795c362c43544380e7a 100))
 
@@ -189,7 +189,7 @@ Even though anybody could initiate the spend of the coin, the person that locked
 
 Conversely lets consider a coin locked up with the following puzzle:
 
-```lisp
+```chialisp
 1
 ```
 
@@ -198,7 +198,7 @@ This puzzle simply returns the entire solution.
 You can think about this in terms of power and control.
 The person that locked the coin up has given all the power to the person who provides the solution.
 
-```lisp
+```chialisp
 $ brun '1' '((51 0xf00dbabe 50) (51 0xfadeddab 50))'
 ((51 0xf00dbabe 50) (51 0xfadeddab 50))
 
@@ -211,12 +211,12 @@ This balance of power determines a lot of how puzzles are designed in ChiaLisp.
 
 For example, let's create a puzzle that lets the spender choose the output, but with one stipulation.
 
-```lisp
+```chialisp
   (c (q . (51 0xcafef00d 200)) 1)
 ```
 This will let the spender return any conditions they want via the solution but will always add the condition to create a coin with the puzzle hash 0xcafef00d and value 200.
 
-```
+```chialisp
 $ brun '(c (q . (51 0xcafef00d 200)) 1)' '((51 0xf00dbabe 75) (51 0xfadeddab 15) (51 0x1234abcd 10))'
 ((51 0xcafef00d 200) (51 0xf00dbabe 75) (51 0xfadeddab 15) (51 0x1234abcd 10))
 ```
@@ -232,7 +232,7 @@ This means that the coin cannot be spent by anybody else, but the outputs are en
 
 We can construct the following smart transaction where AGG_SIG_UNSAFE is 50 and the recipient's pubkey is `0xfadedcab`.
 
-```lisp
+```chialisp
 (c (c (q . 50) (c (q . 0xfadedcab) (c (sha256 2) (q . ())))) 3)
 ```
 
@@ -241,7 +241,7 @@ This puzzle forces the resultant evaluation to contain `(50 pubkey *hash_of_firs
 Let's test it out in clvm_tools - for this example the recipient's pubkey will be represented as 0xdeadbeef.
 The recipient wants to spend the coin to create a new coin which is locked up with the puzzle 0xfadeddab.
 
-```lisp
+```chialisp
 $ brun '(c (c (q . 50) (c (q . 0xfadedcab) (c (sha256 2) ()))) 3)' '("hello" (51 0xcafef00d 200))'
 ((50 0xfadedcab 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824) (51 0xcafef00d 200))
 ```
@@ -289,7 +289,7 @@ We'll go more into SpendBundles and cohesion between coins in a later section.
 
 We can construct an even more powerful version of the signature locked coin:
 
-```lisp
+```chialisp
 (c (c (q . 50) (c (q . 0xfadedcab) (c (sha256 2) ()))) (a 5 11))
 ```
 
@@ -304,13 +304,13 @@ We will cover in more detail how this works in the [next part](/docs/deeper_into
 
 A basic solution for this standard transaction might look like:
 
-```lisp
+```chialisp
 ("hello" (q . ((51 0xmynewpuzzlehash 50) (51 0xanothernewpuzzlehash 50))) ())
 ```
 
 Running that in the clvm_tools looks like this:
 
-```lisp
+```chialisp
 $ brun '(c (c (q . 50) (c (q . 0xfadedcab) (c (sha256 2) ()))) (a 5 11))' '("hello" (q . ((51 0xdeadbeef 50) (51 0xf00dbabe 50))) ())'
 
 ((50 0xfadeddab 0x1f82d4d4c6a32459143cf8f8d27ca04be337a59f07238f1f2c31aaf0cd51d153) (51 0xdeadbeef 50) (51 0xf00dbabe 50))

--- a/docs/deeper_into_clvm.md
+++ b/docs/deeper_into_clvm.md
@@ -15,7 +15,7 @@ ChiaLisp evaluates programs as trees, where the leaves are evaluated first.
 This can cause unexpected problems if you are not aware of it.
 Consider the following program which uses `x` which immediately halts and throws an error if it is evaluated.
 
-```lisp
+```chialisp
 $ brun '(i (q . 1) (q . 100) (x (q . "still being evaluated")))'
 FAIL: clvm raise (0x7374696c6c206265696e67206576616c7561746564)
 ```
@@ -24,13 +24,13 @@ This is because ChiaLisp evaluates both of the leaves even though it will only f
 
 To get around this we can use the following design pattern to replace (i A B C).
 
-```lisp
+```chialisp
 (a (i (A) (q . B) (q . C)) 1)
 ```
 
 Applying this to our above example looks like this:
 
-```lisp
+```chialisp
 $ brun '(a (i (q . 1) (q . (q . 100)) (q . (x (q . "still being evaluated")))) 1)'
 100
 ```
@@ -46,21 +46,20 @@ We can also run programs with new arguments inside a program.
 
 This looks like this:
 
-```lisp
-(a *(puzzle)* (*solution)*)
+```chialisp
+(a *puzzle* *solution*)
 ```
 
 Let's put this into practice.
 
 Here is a program that evaluates the program `(+ 2 (q . 5)))` and uses the list `(70 80 90)` or `(80 90 100)` as the solution.
 
-```lisp
+```chialisp
 $ brun '(a (q . (+ 2 (q . 5))) (q . (70 80 90)))' '(20 30 40)'
 75
 
 $ brun '(a (q . (+ 2 (q . 5))) (q . (80 90 100)))' '(20 30 40)'
 85
-
 ```
 
 Notice how the original solution `(20 30 40)` does not matter for the new evaluation environment.
@@ -69,7 +68,7 @@ In this example we use `q . ` to quote both the new puzzle and the new solution 
 A neat trick that we can pull is that we can define the new solution in terms of the outer solution.
 In this next example we will add the first element of the old solution to our new solution.
 
-```lisp
+```chialisp
 $ brun '(a (q . (+ 2 (q . 5))) (c 2 (q . (70 80 90))))' '(20 30 40)'
 25
 ```
@@ -83,14 +82,14 @@ It does, however, allow programs to be passed as parameters, which can be used f
 
 Here is a puzzle that executes the program contained in `2` (the first solution argument) with the solution `(12)`.
 
-```lisp
+```chialisp
 $ brun '(a 2 (q . (12)))' '((* 2 (q . 2)))'
 24
 ```
 
 Taking this further we can make the puzzle run a new evaluation that only uses parameters from its old solution:
 
-```lisp
+```chialisp
 $ brun '(a 2 1)' '((* 5 (q . 2)) 10)'
 20
 ```

--- a/docs/high_level_lang.md
+++ b/docs/high_level_lang.md
@@ -15,7 +15,7 @@ The first higher level feature you should be aware of is that **it is no longer 
 
 Compare `brun` and `run` here:
 
-```lisp
+```chialisp
 $ brun '(+ 200 200)'
 FAIL: first of non-cons ()
 $ run '(+ 200 200)'
@@ -29,7 +29,7 @@ Run also gives us access to a number of convenient high level operators, which w
 `list` takes any number of parameters and returns them put inside a list.
 This saves us from having to manually create nested `(c (A) (c (B) (q ())))` calls, which can get messy quickly.
 
-```lisp
+```chialisp
 $ run '(list 100 "test" 0xdeadbeef)'
 (100 "test" 0xdeadbeef)
 ```
@@ -38,7 +38,7 @@ $ run '(list 100 "test" 0xdeadbeef)'
 
 `if` automatically puts our `i` statement into the lazy evaluation form so we do not need to worry about the unused code path being evaluated.
 
-```lisp
+```chialisp
 $ run '(if 1 (q . "success") (x))' '(100)'
 "success"
 
@@ -57,7 +57,7 @@ However we will want to change 0xpubkey to a value passed to us through our solu
 
 **Note: `@` allows us to access the arguments in the higher level language (`@` == 1)**
 
-```lisp
+```chialisp
 $ run '(qq (c (c (q . 50) (c (q (unquote (f @))) (c (sha256 2) ()))) (a 5 11)))' '(0xdeadbeef)'
 
 (c (c (q . 50) (c (q . 0xdeadbeef) (c (sha256 2) ()))) (a 5 11))
@@ -75,14 +75,14 @@ This is where `mod` comes in.
 
 Below we name our arguments `arg_one` and `arg_two` and then access `arg_one` inside our main program
 
-```lisp
+```chialisp
 $ run '(mod (arg_one arg_two) (list arg_one))'
 (c 2 ())
 ```
 
 As you can see it returns our program in compiled lower level form.
 
-```lisp
+```chialisp
 $ brun '(c 2 ())' '(100 200 300)'
 (100)
 ```
@@ -96,13 +96,13 @@ In the higher level language we can define functions, macros, and constants befo
 We can define as many of these as we like before the main source code.
 Usually a program will be structured like this:
 
-```lisp
+```chialisp
 (mod (arg_one arg_two)
   (defconstant const_name value)
-  (defun function_name (parameter_one parameter_two) (*function_code*))
-  (defun another_function (param_one param_two param_three) (*function_code*))
-  (defun-inline utility_function (param_one param_two) (*function_code*))
-  (defmacro macro_name (param_one param_two) (*macro_code*))
+  (defun function_name (parameter_one parameter_two) *function_code*)
+  (defun another_function (param_one param_two param_three) *function_code*)
+  (defun-inline utility_function (param_one param_two) *function_code*)
+  (defmacro macro_name (param_one param_two) *macro_code*)
 
   (main *program*)
 )
@@ -120,7 +120,7 @@ A few things to note:
 
 ## Factorial
 
-```lisp
+```chialisp
 (mod (arg_one)
   ; function definitions
   (defun factorial (input)
@@ -135,7 +135,7 @@ A few things to note:
 We can save these files to .clvm files which can be run from the command line.
 Saving the above example as `factorial.clvm` allows us to do the following.
 
-```lisp
+```chialisp
 $ run factorial.clvm
 (a (q 2 2 (c 2 (c 5 ()))) (c (q 2 (i (= 5 (q . 1)) (q 1 . 1) (q 18 (a 2 (c 2 (c (- 5 (q . 1)) ()))) 5)) 1) 1))
 
@@ -154,8 +154,8 @@ This works at any place where you name parameters, and allows you to handle list
 
 Here we define a macro to square a parameter and then a function to square a list.
 
-```lisp
-(mod args
+```chialisp
+(mod (args)
 
   (defmacro square (input)
     (qq (* (unquote input) (unquote input)))
@@ -174,7 +174,7 @@ Here we define a macro to square a parameter and then a function to square a lis
 
 Compiling and running this code results in this:
 
-```lisp
+```chialisp
 $ run square_list.clvm
 (a (q 2 2 (c 2 (c 3 ()))) (c (q 2 (i 5 (q 4 (* 9 9) (a 2 (c 2 (c 13 ())))) (q . 5)) 1) 1))
 

--- a/docs/ref/clvm.md
+++ b/docs/ref/clvm.md
@@ -221,17 +221,16 @@ which is not the same as a single zero byte.
 
 `"A"` is the same atom as `A`
 
-```
+```chialisp
 (q . "A") => 65
 (q . A) => 65
 (q . 65) => 65
 (q . 0x41) => 65
-
 ```
 
 However, the same is not true for Built-ins.
 `"q"` is not the same as `q`
-```
+```chialisp
 (q . q) => 1
 (q . "q") => 113
 ```
@@ -313,7 +312,7 @@ The arithmetic operators `+`, `-`, `*`, `/` and `divmod` treat their arguments a
 
 ### Rounding
 
-```
+```chialisp
 brun '(/ (q . 1)  (q . 2))' => ()
 brun '(/ (q . 2)  (q . 2))' => 1
 brun '(/ (q . 4)  (q . 2))' => 2
@@ -322,7 +321,7 @@ brun '(/ (q . 4)  (q . 2))' => 2
 ### Division of negative numbers
 
 The treatment of negative dividend and divisors is as follows:
-```
+```chialisp
 brun '(/ (q . -1)  (q .  1))' => -1
 brun '(/ (q .  1)  (q . -1))' => -1
 brun '(/ (q . -1)  (q . -1))' =>  1
@@ -330,7 +329,7 @@ brun '(/ (q . -1)  (q . -1))' =>  1
 
 ### Flooring of negative nubmers
 Note that a division with a remainder always rounds down, not toward zero.
-```
+```chialisp
 $ brun '(/ (q . -3) (q . 2))'
 -2
 $ brun '(/ (q . 3) (q . 2))'
@@ -359,7 +358,7 @@ The shorter atom is considered to be extended with zero bytes until equal in len
 
 **lognot** `(lognot A)` bitwise **NOT** of A. All bits are inverted.
 
-```
+```chialisp
 brun '(lognot (q . ()))'
 -1
 brun '(lognot (q . 1))'
@@ -386,7 +385,7 @@ Both **ash** and **lsh** have a maximum |B| of 65536
 
 The third parameter to `substr` is optional. If omitted, the range \[`I1`, `(strlen S)`) is returned.
 
-```
+```chialisp
 (substr (q . "clvm") (q . 0) (q . 4)) => clvm
 (substr (q . "clvm") (q . 2) (q . 4)) => vm
 (substr (q . "clvm") (q . 4) (q . 4)) => ()
@@ -400,7 +399,7 @@ The third parameter to `substr` is optional. If omitted, the range \[`I1`, `(str
 
 **strlen** `(strlen S)` return the number of bytes in `S`.
 
-```
+```chialisp
 (strlen (q . "clvm")) => 4
 (strlen (q . "0x0")) => 3
 (strlen (q . 0x0)) => 1
@@ -418,7 +417,7 @@ Example: `(concat (q . "Hello") (q . " ") (q . "world"))` => `"Hello world"`
 **sha256**
   `(sha256 A ...)` returns the sha256 hash (as a 32-byte blob) of the bytes of its parameters.
 
-```
+```chialisp
 (sha256 (q . "clvm")) => 0xcf3eafb281c0e0e49e19c18b06939a6f7f128595289b08f60c68cef7c0e00b81
 (sha256 (q . "cl") (q . "vm")) => 0xcf3eafb281c0e0e49e19c18b06939a6f7f128595289b08f60c68cef7c0e00b81
 ```
@@ -489,14 +488,14 @@ When used as a parameter that may be checked for nil, zero is interpreted as nil
 ## Detailed behaviour Notes
 
 **ash**
-```
+```chialisp
 (ash (q . 1) (q . 1)) => 2
 (ash (q . 1) (q . -1)) => 0
 ```
 
 Consecutive right shifts of negative numbers will result in a terminal value of -1.
 
-```
+```chialisp
 (ash -7 -1) ; -7 = . . . 111111111111111111111111111001
 (ash -4 -1) ; -4 = . . . 111111111111111111111111111100
 (ash -2 -1) ; -2 = . . . 111111111111111111111111111110
@@ -504,7 +503,7 @@ Consecutive right shifts of negative numbers will result in a terminal value of 
 ```
 
 That is, a right shift (negative shift count) of `-1` by any amount is `-1`:
-```
+```chialisp
 (ash (q . -1) (q . -99)) => -1
 ```
 
@@ -512,7 +511,7 @@ That is, a right shift (negative shift count) of `-1` by any amount is `-1`:
 
 lsh behaviour from the [elisp manual](https://www.gnu.org/software/emacs/manual/pdf/elisp.pdf):
 
-```
+```chialisp
 (ash -7 -1) ; -7 = . . . 111111111111111111111111111001
           ⇒ -4 ; = . . . 111111111111111111111111111100
 
@@ -528,7 +527,7 @@ lsh behaviour from the [elisp manual](https://www.gnu.org/software/emacs/manual/
 
 A left shift of an atom with the high bit set will extend the atom left, and result in an allocation
 
-```
+```chialisp
 (lsh (q . -1) (q . 1)) => 0x01FE
 (strlen (lsh (q . -1) (q . 1))) => 2
 
@@ -538,13 +537,13 @@ A left shift of an atom with the high bit set will extend the atom left, and res
 
 A left arithmetic shift will only extend the atom length when more bits are needed
 
-```
+```chialisp
 (strlen (ash (q . -1) (q . 7))) => 1
 (strlen (ash (q . -1) (q . 8))) => 2
 ```
 
 
-```
+```chialisp
 (strlen (ash (q . 255) (q . 1))) => 2
 (strlen (ash (q . 128) (q . 1))) => 2
 (strlen (ash (q . 127) (q . 1))) => 2

--- a/docs/standard_transaction.md
+++ b/docs/standard_transaction.md
@@ -44,7 +44,7 @@ We'll look at the code in a moment, but here's a few terms to know before you lo
 
 Here's the full source and then we'll break it down:
 
-```lisp
+```chialisp
 (mod
 
     (SYNTHETIC_PUBLIC_KEY original_public_key delegated_puzzle solution)
@@ -54,7 +54,7 @@ Here's the full source and then we'll break it down:
     ; all of A0, A1, ... An must evaluate to non-null, or an exception is raised
     ; return the last item (if we get that far)
 
-    (defmacro assert items
+    (defmacro assert (items)
         (if (r items)
             (list if (f items) (c assert (r items)) (q . (x)))
             (f items)
@@ -98,7 +98,7 @@ Here's the full source and then we'll break it down:
 
 That's probably a lot to digest so let's break it down piece by piece.  First, let's talk about the arguments:
 
-```lisp
+```
 (SYNTHETIC_PUBLIC_KEY original_public_key delegated_puzzle solution)
 ```
 
@@ -110,7 +110,7 @@ All of these terms are defined above.  When we solve this puzzle:
 
 As with most Chialisp programs, we'll start looking at the implementation from the bottom:
 
-```lisp
+```chialisp
 (possibly_prepend_aggsig
     SYNTHETIC_PUBLIC_KEY original_public_key delegated_puzzle
     (a delegated_puzzle solution))
@@ -118,7 +118,7 @@ As with most Chialisp programs, we'll start looking at the implementation from t
 
 There's nothing much going on here, we're mostly just passing arguments to `possibly_prepend_aggsig` to start the program.  The only thing to note is that we're evaluating the delegated puzzle with the solution before passing it in.  This will result in a list of conditions that we will output as long as the rest of the puzzle checks out.
 
-```lisp
+```chialisp
 (defun-inline possibly_prepend_aggsig (SYNTHETIC_PUBLIC_KEY original_public_key delegated_puzzle conditions)
   (if original_public_key
       (assert
@@ -134,7 +134,7 @@ This function is the main control flow logic that determines whether we're doing
 
 If the spend is the hidden spend, we pass most of our parameters to `is_hidden_puzzle_correct` and, as long as it doesn't fail, we just return whatever conditions are given to us.  If the spend is the delegated spend, we prepend a signature requirement from the curried in public key on the hash of the delegated puzzle.
 
-```lisp
+```chialisp
 (defun-inline is_hidden_puzzle_correct (SYNTHETIC_PUBLIC_KEY original_public_key delegated_puzzle)
   (=
       SYNTHETIC_PUBLIC_KEY

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,8 @@ module.exports = {
   projectName: 'chialisp-web', // Usually your repo name.
   themeConfig: {
     prism: {
-      theme: require('./src/theme/prism-dark-theme-chialisp')
+      darkTheme: require('./src/theme/prism-dark-theme-chialisp'),
+      theme: require('./src/theme/prism-light-theme-chialisp')
     },
     navbar: {
       title: 'Chialisp',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,6 +8,9 @@ module.exports = {
   organizationName: 'Chia-Network', // Usually your GitHub org/user name.
   projectName: 'chialisp-web', // Usually your repo name.
   themeConfig: {
+    prism: {
+      theme: require('./src/theme/prism-dark-theme-chialisp')
+    },
     navbar: {
       title: 'Chialisp',
       logo: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,118 +26,118 @@
       "integrity": "sha512-2oQZPERYV+yNx/yoVWYjZZdOqsitJ5dfxXJjL18yczOXH6ujnsq+DTczSrX+RjzjQdVeJ1UAG053EJQF/FOiMg=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.9.1.tgz",
-      "integrity": "sha512-bAUU9vKCy45uTTlzJw0LYu1IjoZsmzL6lgjaVFaW1crhX/4P+JD5ReQv3n/wpiXSFaHq1WEO3WyH2g3ymzeipQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.10.2.tgz",
+      "integrity": "sha512-B3NInwobEAim4J4Y0mgZermoi0DCXdTT/Q+4ehLamqUqxLw8To5zc9izjg7B8JaFSQsqflRdCeRmYEv2gYDY7g==",
       "requires": {
-        "@algolia/cache-common": "4.9.1"
+        "@algolia/cache-common": "4.10.2"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.9.1.tgz",
-      "integrity": "sha512-tcvw4mOfFy44V4ZxDEy9wNGr6vFROZKRpXKTEBgdw/WBn6mX51H1ar4RWtceDEcDU4H5fIv5tsY3ip2hU+fTPg=="
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.10.2.tgz",
+      "integrity": "sha512-xcGbV0+6gLu2C7XoJdD+Pp6wWjROle6PNDsa6O21vS7fw1a03xb2bEnFdl1U31bs69P1z8IRy3h+8RVBouvhhw=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.9.1.tgz",
-      "integrity": "sha512-IEJrHonvdymW2CnRfJtsTVWyfAH05xPEFkGXGCw00+6JNCj8Dln3TeaRLiaaY1srlyGedkemekQm1/Xb46CGOQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.10.2.tgz",
+      "integrity": "sha512-zPIcxHQEJXy+M35A+v9Y5u5BAQOKR2aFK0kYpAdW/OrgxYcrFHtVCxwIWB/ZhGbkDtzCW8/8tJeddcD5YsHX9Q==",
       "requires": {
-        "@algolia/cache-common": "4.9.1"
+        "@algolia/cache-common": "4.10.2"
       }
     },
     "@algolia/client-account": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.9.1.tgz",
-      "integrity": "sha512-Shpjeuwb7i2LR5QuWREb6UbEQLGB+Pl/J5+wPgILJDP/uWp7jpl0ase9mYNQGKj7TjztpSpQCPZ3dSHPnzZPfw==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.10.2.tgz",
+      "integrity": "sha512-iuIU+xUtjgR9p4Hpujlr8mePDPSrVIk3peg+RAUhxniLBDaI+OhgHyhP6Lmh9flWk+JfRg91Rhk46xuxMLqwfA==",
       "requires": {
-        "@algolia/client-common": "4.9.1",
-        "@algolia/client-search": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/client-common": "4.10.2",
+        "@algolia/client-search": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.9.1.tgz",
-      "integrity": "sha512-/g6OkOSIA+A0t/tjvbL6iG/zV4El4LPFgv/tcAYHTH27BmlNtnEXw+iFpGjeUlQoPily9WVB3QNLMJkaNwL3HA==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.10.2.tgz",
+      "integrity": "sha512-u47J65NHs0fMryDrMeuLMGjXDOKt/muF9WlfbMslT2Cvdd7PZwl9KYnT7xMhnmBB8TDiDMmEQkDykhnCOnwVNw==",
       "requires": {
-        "@algolia/client-common": "4.9.1",
-        "@algolia/client-search": "4.9.1",
-        "@algolia/requester-common": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/client-common": "4.10.2",
+        "@algolia/client-search": "4.10.2",
+        "@algolia/requester-common": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
     "@algolia/client-common": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.9.1.tgz",
-      "integrity": "sha512-UziRTZ8km3qwoVPIyEre8TV6V+MX7UtbfVqPmSafZ0xu41UUZ+sL56YoKjOXkbKuybeIC9prXMGy/ID5bXkTqg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.10.2.tgz",
+      "integrity": "sha512-sfgZCv9ha9aHbe3ErAYb1blg2qx4XTLvQqP1jq8asU75rrH9XBTtSzQQO43GlArwhtwCHLgcWquN3WgPlLzkiQ==",
       "requires": {
-        "@algolia/requester-common": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/requester-common": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
-    "@algolia/client-recommendation": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.9.1.tgz",
-      "integrity": "sha512-Drtvvm1PNIOpYf4HFlkPFstFQ3IsN+TRmxur2F7y6Faplb5ybISa8ithu1tmlTdyTf3A78hQUQjgJet6qD2XZw==",
+    "@algolia/client-personalization": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.10.2.tgz",
+      "integrity": "sha512-2UhUNo/czfA/keOC3+vFyMnFGV/E1Zkm+ek9Fsk/9miS39UMhx2CmH5vKSIJ7jxLSin7zBaCwKt65phfYty1pg==",
       "requires": {
-        "@algolia/client-common": "4.9.1",
-        "@algolia/requester-common": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/client-common": "4.10.2",
+        "@algolia/requester-common": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
     "@algolia/client-search": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.9.1.tgz",
-      "integrity": "sha512-r9Cw2r8kJr45iYncFDht6EshARghU265wuY8Q8oHrpFHjAziEYdsUOdNmQKbsSH5J3gLjDPx1EI5DzVd6ivn3w==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.10.2.tgz",
+      "integrity": "sha512-ZdOh6XS6Y9bcekfG4y0VhdoIYfsTounsgXX4Bt3X2RCcmY3uotgaq2EVY58E6q6nvfgBfPHW18+AZCHKTWHAAw==",
       "requires": {
-        "@algolia/client-common": "4.9.1",
-        "@algolia/requester-common": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/client-common": "4.10.2",
+        "@algolia/requester-common": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
     "@algolia/logger-common": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.9.1.tgz",
-      "integrity": "sha512-9mPrbFlFyPT7or/7PXTiJjyOewWB9QRkZKVXkt5zHAUiUzGxmmdpJIGpPv3YQnDur8lXrXaRI0MHXUuIDMY1ng=="
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.10.2.tgz",
+      "integrity": "sha512-UJaU6arzmW+FT5fCv5NIbxNMtEoGcf+UENmZxxu7k7UWPARR2XL4ljJ45Jv14Z5dlz32LXWtR1PRmNfkDMk22Q=="
     },
     "@algolia/logger-console": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.9.1.tgz",
-      "integrity": "sha512-74VUwjtFjFpjZpi3QoHIPv0kcr3vWUSHX/Vs8PJW3lPsD4CgyhFenQbG9v+ZnyH0JrJwiYTtzfmrVh7IMWZGrQ==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.10.2.tgz",
+      "integrity": "sha512-JrCrZ7CGs/TsyNR2AWe9Vdd6rsuxfvfcpqbu+CY7LBUYEnV8GERkf7FnDNaKVNsFJqClILCGh3U8CzQ1G5L+kA==",
       "requires": {
-        "@algolia/logger-common": "4.9.1"
+        "@algolia/logger-common": "4.10.2"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.9.1.tgz",
-      "integrity": "sha512-zc46tk5o0ikOAz3uYiRAMxC2iVKAMFKT7nNZnLB5IzT0uqAh7pz/+D/UvIxP4bKmsllpBSnPcpfQF+OI4Ag/BA==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.10.2.tgz",
+      "integrity": "sha512-LveaAp7/oCBotv1aZ4VHz8fCcJA7v/28ayh+Ljlm+hYXsxgs6NAYKz7iBpxGN7q5MV8GM+MThRYNFoT0cHTMxQ==",
       "requires": {
-        "@algolia/requester-common": "4.9.1"
+        "@algolia/requester-common": "4.10.2"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.9.1.tgz",
-      "integrity": "sha512-9hPgXnlCSbqJqF69M5x5WN3h51Dc+mk/iWNeJSVxExHGvCDfBBZd0v6S15i8q2a9cD1I2RnhMpbnX5BmGtabVA=="
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.10.2.tgz",
+      "integrity": "sha512-3J2W0fAaURLGK0lEGeNb8eWJnQcsu+oIcfJTCIYkYT5T9w21M65kUUyD9QSf/K137qQts3tzGniUR3LxfovlXA=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.9.1.tgz",
-      "integrity": "sha512-vYNVbSCuyrCSCjHBQJk+tLZtWCjvvDf5tSbRJjyJYMqpnXuIuP7gZm24iHil4NPYBhbBj5NU2ZDAhc/gTn75Ag==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.10.2.tgz",
+      "integrity": "sha512-IBqsalCGgn0CrOP1PKRB5rufEOvHlrSQUFEGXZ8mxmE/zU8CLX2LKqdHbEFeNDLFl+l+8HW5BGVDGD2rvG+hSg==",
       "requires": {
-        "@algolia/requester-common": "4.9.1"
+        "@algolia/requester-common": "4.10.2"
       }
     },
     "@algolia/transporter": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.9.1.tgz",
-      "integrity": "sha512-AbjFfGzX+cAuj7Qyc536OxIQzjFOA5FU2ANGStx8LBH+AKXScwfkx67C05riuaRR5adSCLMSEbVvUscH0nF+6A==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.10.2.tgz",
+      "integrity": "sha512-I3QDRSookQtPSUEnxT2XCShhipCT4beJBpWhteNwMrWQF/SqTsveqSR6bX0G49lDh9MOmYrOlCegteuKuT/tEw==",
       "requires": {
-        "@algolia/cache-common": "4.9.1",
-        "@algolia/logger-common": "4.9.1",
-        "@algolia/requester-common": "4.9.1"
+        "@algolia/cache-common": "4.10.2",
+        "@algolia/logger-common": "4.10.2",
+        "@algolia/requester-common": "4.10.2"
       }
     },
     "@babel/code-frame": {
@@ -727,11 +727,18 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
-      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        }
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -1032,18 +1039,45 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.3.tgz",
-      "integrity": "sha512-t960xbi8wpTFE623ef7sd+UpEC5T6EEguQlTBJDEO05+XwnIWVfuqLw/vdLWY6IdFmtZE+65CZAfByT39zRpkg==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.14.5.tgz",
+      "integrity": "sha512-fPMBhh1AV8ZyneiCIA+wYYUH1arzlXR1UMcApjvchDhfKxhy2r2lReJv8uHEyihi4IFIGlr1Pdx7S5fkESDQsg==",
       "requires": {
-        "@babel/helper-module-imports": "^7.13.12",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "babel-plugin-polyfill-corejs2": "^0.2.0",
-        "babel-plugin-polyfill-corejs3": "^0.2.0",
-        "babel-plugin-polyfill-regenerator": "^0.2.0",
+        "@babel/helper-module-imports": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-polyfill-corejs2": "^0.2.2",
+        "babel-plugin-polyfill-corejs3": "^0.2.2",
+        "babel-plugin-polyfill-regenerator": "^0.2.2",
         "semver": "^6.3.0"
       },
       "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+        },
+        "@babel/types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1093,13 +1127,185 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.14.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.4.tgz",
-      "integrity": "sha512-WYdcGNEO7mCCZ2XzRlxwGj3PgeAr50ifkofOUC/+IN/GzKLB+biDPVBUAQN2C/dVZTvEXCp80kfQ1FFZPrwykQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.6.tgz",
+      "integrity": "sha512-XlTdBq7Awr4FYIzqhmYY80WN0V0azF74DMPyFqVHBvf81ZUgc4X7ZOpx6O8eLDK6iM5cCQzeyJw0ynTaefixRA==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.14.4",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-typescript": "^7.12.13"
+        "@babel/helper-create-class-features-plugin": "^7.14.6",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+          "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+          "requires": {
+            "@babel/types": "^7.14.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+          "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.6.tgz",
+          "integrity": "sha512-Z6gsfGofTxH/+LQXqYEK45kxmcensbzmk/oi8DmaQytlQCgqNZt9XQF8iqlI/SeXWVjaMNxvYvzaYw+kh42mDg==",
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-member-expression-to-functions": "^7.14.5",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+          "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+          "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+          "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.14.5",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+        },
+        "@babel/template": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.14.7",
+            "@babel/types": "^7.14.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
@@ -1232,13 +1438,25 @@
       }
     },
     "@babel/preset-typescript": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.13.0.tgz",
-      "integrity": "sha512-LXJwxrHy0N3f6gIJlYbLta1D9BDtHpQeqwzM0LIfjDlr6UE/D5Mc7W4iDiQzaE+ks0sTjT26ArcHWnJVt0QiHw==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz",
+      "integrity": "sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-transform-typescript": "^7.13.0"
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+          "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+          "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+        }
       }
     },
     "@babel/runtime": {
@@ -1250,11 +1468,11 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.0.tgz",
-      "integrity": "sha512-0R0HTZWHLk6G8jIk0FtoX+AatCtKnswS98VhXwGImFc759PJRp4Tru0PQYZofyijTFUr+gT8Mu7sgXVJLQ0ceg==",
+      "version": "7.14.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.7.tgz",
+      "integrity": "sha512-Wvzcw4mBYbTagyBVZpAJWI06auSIj033T/yNE0Zn1xcup83MieCddZA7ls3kme17L4NOGBrQ09Q+nKB41RLWBA==",
       "requires": {
-        "core-js-pure": "^3.0.0",
+        "core-js-pure": "^3.15.0",
         "regenerator-runtime": "^0.13.4"
       }
     },
@@ -1309,9 +1527,9 @@
       }
     },
     "@docusaurus/core": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-+4Mmm5Zi1AvnFi0r/KfwSrXqOVQQPXQN610KcwrNsfXvq2QTR5O7QwXzUdZSERLQ183+iI1PD4x7bAiSSmwUBw==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.0-beta.2.tgz",
+      "integrity": "sha512-i0jwYyTFkWUhnN5/eky7fkt7reIvNFH5iOyltXyCxn/DrKCGRqC63g3IbFhvLULl007JKp3vBXvwcNK3IpH8Yw==",
       "requires": {
         "@babel/core": "^7.12.16",
         "@babel/generator": "^7.12.15",
@@ -1323,12 +1541,13 @@
         "@babel/runtime": "^7.12.5",
         "@babel/runtime-corejs3": "^7.12.13",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/cssnano-preset": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/cssnano-preset": "2.0.0-beta.2",
         "@docusaurus/react-loadable": "5.5.0",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
-        "@endiliey/static-site-generator-webpack-plugin": "^4.0.0",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-common": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.0",
         "@svgr/webpack": "^5.5.0",
         "autoprefixer": "^10.2.5",
         "babel-loader": "^8.2.2",
@@ -1338,13 +1557,14 @@
         "chokidar": "^3.5.1",
         "clean-css": "^5.1.2",
         "commander": "^5.1.0",
-        "copy-webpack-plugin": "^8.1.1",
+        "copy-webpack-plugin": "^9.0.0",
         "core-js": "^3.9.1",
         "css-loader": "^5.1.1",
-        "css-minimizer-webpack-plugin": "^2.0.0",
+        "css-minimizer-webpack-plugin": "^3.0.1",
         "cssnano": "^5.0.4",
         "del": "^6.0.0",
         "detect-port": "^1.3.0",
+        "escape-html": "^1.0.3",
         "eta": "^1.12.1",
         "express": "^4.17.1",
         "file-loader": "^6.2.0",
@@ -1353,7 +1573,7 @@
         "globby": "^11.0.2",
         "html-minifier-terser": "^5.1.1",
         "html-tags": "^3.1.0",
-        "html-webpack-plugin": "^5.3.1",
+        "html-webpack-plugin": "^5.3.2",
         "import-fresh": "^3.3.0",
         "is-root": "^2.1.0",
         "leven": "^3.1.0",
@@ -1379,22 +1599,22 @@
         "shelljs": "^0.8.4",
         "std-env": "^2.2.1",
         "strip-ansi": "^6.0.0",
-        "terser-webpack-plugin": "^5.1.2",
+        "terser-webpack-plugin": "^5.1.3",
         "tslib": "^2.2.0",
         "update-notifier": "^5.1.0",
         "url-loader": "^4.1.1",
         "wait-on": "^5.3.0",
-        "webpack": "^5.37.0",
+        "webpack": "^5.40.0",
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-dev-server": "^3.11.2",
-        "webpack-merge": "^5.7.3",
+        "webpack-merge": "^5.8.0",
         "webpackbar": "^5.0.0-3"
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-yoiQSxzYYWXqNgVfXG0gdsx28lUDi/vGvCpE1qZXX/0Nxyy3fOdWbktmaBx+qJrR+xD+SdGJXVuwX0w95NiIYQ==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.2.tgz",
+      "integrity": "sha512-GNGYkePEYWJkxgFNUBYjEUySKm5FfBbYoQqGWn6KxDN34Qi7o+Wb37zPOiz2pNKBq+qCvXOfCIqblq7n0S/POA==",
       "requires": {
         "cssnano-preset-advanced": "^5.1.1",
         "postcss": "^8.2.15",
@@ -1402,14 +1622,14 @@
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-cgZuUFxUNui3UMlA4es2Bc71HS6DEnmDQ74UdZlxCvRZXASgoT2a8T2ATilSmT1b7srgWmBORAqsJ154tW+R5w==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.2.tgz",
+      "integrity": "sha512-ZUqwQQY3P9/N2KBt28ADJgQWj98VqKG0+OEQJOiK6bd8uIngLrHvWE0WasBT3zgPK+ljhdRMaQ7TWt1Doot+ZA==",
       "requires": {
         "@babel/parser": "^7.12.16",
         "@babel/traverse": "^7.12.13",
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "escape-html": "^1.0.3",
@@ -1422,27 +1642,21 @@
         "stringify-object": "^3.3.0",
         "unist-util-visit": "^2.0.2",
         "url-loader": "^4.1.1",
-        "webpack": "^5.37.0"
-      },
-      "dependencies": {
-        "@mdx-js/react": {
-          "version": "1.6.22",
-          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-          "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
-        }
+        "webpack": "^5.40.0"
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-abd9Fnqn7kYifIVUdYVwC9yeG2lEBFn3T0fNREplmrjtdNQUWfXx8hGMKOhigXmIzWjGdqtti3/2pLmRxomNIA==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.2.tgz",
+      "integrity": "sha512-I4q8zwL2GpfBxebDWoKWBrEtV2oiOkrc8cP5JORw5HKKB9zOz99UcggnbanllkCtmj+o4RiuhCQ0vHPFB5ts3Q==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/mdx-loader": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/mdx-loader": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "chalk": "^4.1.1",
+        "escape-string-regexp": "^4.0.0",
         "feed": "^4.2.2",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.2",
@@ -1451,21 +1665,29 @@
         "reading-time": "^1.3.0",
         "remark-admonitions": "^1.2.1",
         "tslib": "^2.2.0",
-        "webpack": "^5.37.0"
+        "webpack": "^5.40.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-OSwna5U19PUw2GOKd4ZgYIfisVLXsmwVNYpsrIznNnTeschbpdcowRbfgxAxzwglRMwPbP7WkoqI4D5M0x5BJg==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.2.tgz",
+      "integrity": "sha512-lx7jC+DqMMio0Hhq3DNNGZKNUAD5n5Sc0T1m5x67iXoRJPwOEmKa+8fEhGV4tmXpTy7EmULpAnS+OxlJDOPhxg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/mdx-loader": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/mdx-loader": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "chalk": "^4.1.1",
         "combine-promises": "^1.1.0",
+        "escape-string-regexp": "^4.0.0",
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.2",
@@ -1477,7 +1699,7 @@
         "shelljs": "^0.8.4",
         "tslib": "^2.2.0",
         "utility-types": "^3.10.0",
-        "webpack": "^5.37.0"
+        "webpack": "^5.40.0"
       },
       "dependencies": {
         "argparse": {
@@ -1485,10 +1707,15 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
         "execa": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.1.tgz",
-          "integrity": "sha512-4hFTjFbFzQa3aCLobpbPJR/U+VoL1wdV5ozOWjeet0AWDeYr9UFGM1eUFWHX+VtOWFq4p0xXUXfW1YxUaP4fpw==",
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
           "requires": {
             "cross-spawn": "^7.0.3",
             "get-stream": "^6.0.0",
@@ -1548,81 +1775,82 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-6JhUrzofphDA5qxD1CMzQ4bNnS6tbCeklC6ld7D/ubqfb0/vLxQBixGwMSkkxlTGsa8eEcjh4W4fAoUjGnTXOg==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.2.tgz",
+      "integrity": "sha512-Hl8GG6PpAH4AV3i5QxmxggUet/ONl9E7FdfbJ/aKsjqziay2nW6LS66Ug9EchWlEoWKpmgTvRKRKhqAIJkBzXA==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/mdx-loader": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/mdx-loader": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "globby": "^11.0.2",
         "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "remark-admonitions": "^1.2.1",
         "slash": "^3.0.0",
         "tslib": "^2.1.0",
-        "webpack": "^5.28.0"
+        "webpack": "^5.40.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-5cNs/HbtWh3nn3Bim35XN0KtfleyR6Ju07Yt7RKdlvPCRNKm/wUtFEcUayuuY6nyyF9WYvjH/k7rd4AhO098AA==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.2.tgz",
+      "integrity": "sha512-Lej0Smd6wznFVOmMDQ5SU/cwOYgns63wKC6gRFBWJpZPYhmFsMOSbHTMVkAFJ5cdXeyomx51MkIH43aBytIqXQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
         "react-json-view": "^1.21.3",
         "tslib": "^2.1.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-An3rdHpVjf8RZiZqxcQMO+nTE6vz6isowP1QsfPjiyVLFercQ116RuBodUTjkyOV/rCL1bHvdh9B2G8dp79Zbw==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.2.tgz",
+      "integrity": "sha512-hOnmhCoUn1wbMb6kS2HTmVFsMmx7VaAuH+OEJMX1mJ+bAlQg3Btoctvs1BivEl2WGVvV0M5zjHW1+zwZp/QFOw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff"
+        "@docusaurus/core": "2.0.0-beta.2"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-4nNafEi8wfikxVKY8JKClglSP0vd5ahlSix4b1wsYNcPqxeJQHwx2VIkRDIPdvO9ySFdRMetzWr/pNMsxb/xpA==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.2.tgz",
+      "integrity": "sha512-9ugXaVZJF5YOWzKjLevXdSXjfEPndD1Qc46eJ0l43golLXXC+b0u0gdOMms9r+HCK6/OBqTbMKcejWIUBlx0wQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff"
+        "@docusaurus/core": "2.0.0-beta.2"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-4z0hpdlPgwWU9sVVUdwiHCgnm7IVvAw8LaEzZmbMfZcVON3ImGNOHRMxgN85C29xWT/QwSx6k9NL+paB/gorGQ==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.2.tgz",
+      "integrity": "sha512-tyoqZs52nVoAN7ZxJjGnpF6TUEVmXIpcGWfo0ehuTsNDs1f0XTOpex6Ue5ddXd2cEXht0HfWcL/Ta93R8BDBFw==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-common": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "fs-extra": "^10.0.0",
         "sitemap": "^7.0.0",
         "tslib": "^2.2.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-kXTtH1CygI7+jL/Tr2gQwGytE4IZti/Nep7f3p+i0I4euihMz90413CUHdp6/jx3HnrzcO5lPKAfdlZXbKh5Rw==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.2.tgz",
+      "integrity": "sha512-ZdnCubWLoXrHgneHLQNoecwG3Cr19VBEOFOOebvMRCjGCfwyfJ7smBdx0Igvl7t+r9cAAnQtshPv5k6b4QPFKQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-debug": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-google-analytics": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-google-gtag": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-sitemap": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/theme-classic": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/theme-search-algolia": "2.0.0-beta.ff31de0ff"
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.2",
+        "@docusaurus/plugin-debug": "2.0.0-beta.2",
+        "@docusaurus/plugin-google-analytics": "2.0.0-beta.2",
+        "@docusaurus/plugin-google-gtag": "2.0.0-beta.2",
+        "@docusaurus/plugin-sitemap": "2.0.0-beta.2",
+        "@docusaurus/theme-classic": "2.0.0-beta.2",
+        "@docusaurus/theme-search-algolia": "2.0.0-beta.2"
       }
     },
     "@docusaurus/react-loadable": {
@@ -1634,18 +1862,19 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-qiV+rgqZIKSzd0DKPgCQCyBP/LQiocqhhwIAWoOxvhbeUx4mmBAt2JtrQQnvg5jPOpa6uKVDu0JAamE1ldP5rg==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.2.tgz",
+      "integrity": "sha512-z6hJ3KyH+xmlAv5s+IgUek+eiWfkAwq2GTqCi9X6HdRmMSLxgmW7ikzK2fXVtk0VlhLxn/lBHds6Nvfo0YKCKg==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/theme-common": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.2",
+        "@docusaurus/theme-common": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-common": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "@mdx-js/mdx": "^1.6.21",
         "@mdx-js/react": "^1.6.21",
         "chalk": "^4.1.1",
@@ -1653,7 +1882,7 @@
         "copy-text-to-clipboard": "^3.0.1",
         "fs-extra": "^10.0.0",
         "globby": "^11.0.2",
-        "infima": "0.2.0-alpha.23",
+        "infima": "0.2.0-alpha.26",
         "lodash": "^4.17.20",
         "parse-numeric-range": "^1.2.0",
         "postcss": "^8.2.15",
@@ -1662,38 +1891,31 @@
         "prop-types": "^15.7.2",
         "react-router-dom": "^5.2.0",
         "rtlcss": "^3.1.2"
-      },
-      "dependencies": {
-        "@mdx-js/react": {
-          "version": "1.6.22",
-          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-          "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
-        }
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-v98AvBy3F2qWuqofN30E/lvrA/B0eh+0g9Ly5Y3ZSJxMovGazp8jbP1YJ6pnz+ttUvbZEOFLpV9SUMe7ZMcB4Q==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.0.0-beta.2.tgz",
+      "integrity": "sha512-4svDbPYpwFCb646rcayK029LANdnIHMhMFX1Out1EWcLmFFfAXY3YtWoX5iW4KEM9ScbxPisz0dKb2BVupJ6MQ==",
       "requires": {
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-blog": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-docs": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/plugin-content-pages": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-blog": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-docs": "2.0.0-beta.2",
+        "@docusaurus/plugin-content-pages": "2.0.0-beta.2",
+        "@docusaurus/types": "2.0.0-beta.2",
         "tslib": "^2.1.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-eTtObHogSlC+FGMhR7f5LAt3q3S8UCsJ3x0OMCnZM8AF6NS7aMJX26T4isyDv1j6xY3quUJiortFLyZ65Is78g==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.2.tgz",
+      "integrity": "sha512-bVzZ2GF94BysasqW+PeggP9BBijUFTcnCeIp2BjOkaRnHW1YNfsfhdGArWS/2WKMWi4Y1vu79UDAKR7svCKNjg==",
       "requires": {
-        "@docsearch/react": "^3.0.0-alpha.33",
-        "@docusaurus/core": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/theme-common": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
-        "@docusaurus/utils-validation": "2.0.0-beta.ff31de0ff",
+        "@docsearch/react": "^3.0.0-alpha.36",
+        "@docusaurus/core": "2.0.0-beta.2",
+        "@docusaurus/theme-common": "2.0.0-beta.2",
+        "@docusaurus/utils": "2.0.0-beta.2",
+        "@docusaurus/utils-validation": "2.0.0-beta.2",
         "algoliasearch": "^4.8.4",
         "algoliasearch-helper": "^3.3.4",
         "clsx": "^1.1.1",
@@ -1702,23 +1924,23 @@
       }
     },
     "@docusaurus/types": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-7kr1nCXtlRlU5PyBgQJzAxpamCnZcMz1syjzMWGR5Njxt4ejXIBz3nPpLA5DPoVpFqi5BhCld5V2wQ/JhAYV9w==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.0.0-beta.2.tgz",
+      "integrity": "sha512-4lANZLq//nYukGH0TK/EVszq3SVvz2VADXXT5o39Hx1sghkVXhJBb0jX1GaSsn1aUUW6kJr9IbiaZdfifi2bNg==",
       "requires": {
         "commander": "^5.1.0",
         "joi": "^17.4.0",
         "querystring": "0.2.0",
-        "webpack": "^5.37.0",
-        "webpack-merge": "^5.7.3"
+        "webpack": "^5.40.0",
+        "webpack-merge": "^5.8.0"
       }
     },
     "@docusaurus/utils": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-Dr8qOjScfSVpMMxxb4UsEl2bReRMmflcsJ+gKwfx73lOvXFOcYF2+zF0h0Hy8PRzxiEhTBus7/6S0U8YoYNWvQ==",
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.0.0-beta.2.tgz",
+      "integrity": "sha512-4nmfNZhl6zGMI+KJFEjLXWWyniMaESct5Oigqa55RbBXUtRI4isaOOMEjlfY+Q/jrJxQozRSuWKWM81VM3z6Yg==",
       "requires": {
-        "@docusaurus/types": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/types": "2.0.0-beta.2",
         "@types/github-slugger": "^1.3.0",
         "chalk": "^4.1.1",
         "escape-string-regexp": "^4.0.0",
@@ -1736,43 +1958,24 @@
         }
       }
     },
-    "@docusaurus/utils-validation": {
-      "version": "2.0.0-beta.ff31de0ff",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.ff31de0ff.tgz",
-      "integrity": "sha512-IcgA+nqQvCakMSCkf2Lxs5rVGRvBpgyhtq9O1XKGfFU30gxVgB2xySUxQrfzGcmCjJaZ8G8xtF7PD3BfB3pZiw==",
+    "@docusaurus/utils-common": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.0.0-beta.2.tgz",
+      "integrity": "sha512-R2D3wr49kc0TVWQBiKWhM32wsdZQj2ioYT6+eyyKW8f4yRP731TpO1k0pL/c9/UVA5i3Qtei+/3+guFcfxJ7VQ==",
       "requires": {
-        "@docusaurus/utils": "2.0.0-beta.ff31de0ff",
+        "@docusaurus/types": "2.0.0-beta.2",
+        "tslib": "^2.2.0"
+      }
+    },
+    "@docusaurus/utils-validation": {
+      "version": "2.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.2.tgz",
+      "integrity": "sha512-JMS74ldYsRxoaWXmHrOnvwSZqAMtddbuCd3wrGSWHbJNX9PI6nNqdXJDHjHTyN6kiykU7U4Hhh7D47ICdUSGEQ==",
+      "requires": {
+        "@docusaurus/utils": "2.0.0-beta.2",
         "chalk": "^4.1.1",
         "joi": "^17.4.0",
         "tslib": "^2.1.0"
-      }
-    },
-    "@endiliey/static-site-generator-webpack-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@endiliey/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.0.tgz",
-      "integrity": "sha512-3MBqYCs30qk1OBRC697NqhGouYbs71D1B8hrk/AFJC6GwF2QaJOQZtA1JYAaGSe650sZ8r5ppRTtCRXepDWlng==",
-      "requires": {
-        "bluebird": "^3.7.1",
-        "cheerio": "^0.22.0",
-        "eval": "^0.1.4",
-        "url": "^0.11.0",
-        "webpack-sources": "^1.4.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "webpack-sources": {
-          "version": "1.4.3",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-          "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
-          }
-        }
       }
     },
     "@hapi/hoek": {
@@ -1781,9 +1984,9 @@
       "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
     },
     "@hapi/topo": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
-      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -1853,9 +2056,9 @@
       }
     },
     "@mdx-js/react": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.16.tgz",
-      "integrity": "sha512-+FhuSVOPo7+4fZaRwWuCSRUcZkJOkZu0rfAbBKvoCg1LWb1Td8Vzi0DTLORdSvgWNbU6+EL40HIgwTOs00x2Jw=="
+      "version": "1.6.22",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+      "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg=="
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -1863,25 +2066,25 @@
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
     "@nodelib/fs.scandir": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
-      "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "requires": {
-        "@nodelib/fs.stat": "2.0.4",
+        "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
-      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
-      "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
+      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
       "requires": {
-        "@nodelib/fs.scandir": "2.1.4",
+        "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
     },
@@ -1912,6 +2115,34 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@slorber/static-site-generator-webpack-plugin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.1.tgz",
+      "integrity": "sha512-PSv4RIVO1Y3kvHxjvqeVisk3E9XFoO04uwYBDWe217MFqKspplYswTuKLiJu0aLORQWzuQjfVsSlLPojwfYsLw==",
+      "requires": {
+        "bluebird": "^3.7.1",
+        "cheerio": "^0.22.0",
+        "eval": "^0.1.4",
+        "url": "^0.11.0",
+        "webpack-sources": "^1.4.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "webpack-sources": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+          "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+          "requires": {
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
+          }
+        }
+      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "5.4.0",
@@ -2159,9 +2390,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.47",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.47.tgz",
-      "integrity": "sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg=="
+      "version": "0.0.48",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
+      "integrity": "sha512-LfZwXoGUDo0C3me81HXgkBg5CTQYb6xzEl+fNmbO4JdRiSKQ8A0GD1OBBvKAIsbCUgoyAty7m99GqqMQe784ew=="
     },
     "@types/github-slugger": {
       "version": "1.3.0",
@@ -2209,9 +2440,9 @@
       "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
     },
     "@types/node": {
-      "version": "15.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
-      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA=="
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -2392,14 +2623,14 @@
       }
     },
     "acorn": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.3.0.tgz",
-      "integrity": "sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw=="
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
     },
     "acorn-walk": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.0.tgz",
-      "integrity": "sha512-mjmzmv12YIG/G8JQdQuz2MUDShEJ6teYpT5bmWA4q7iwoGen8xtt3twF3OvzIUl+Q06aWIjvnwQUKvQ6TtMRjg=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
+      "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w=="
     },
     "address": {
       "version": "1.1.2",
@@ -2437,30 +2668,30 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
     },
     "algoliasearch": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.9.1.tgz",
-      "integrity": "sha512-EeJUYXzBEhZSsL6tXc3hseLBCtlNLa1MZ4mlMK6EeX38yRjY5vgnFcNNml6uUhlOjvheKxgkKRpPWkxgL8Cqkg==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.10.2.tgz",
+      "integrity": "sha512-BAYCe97XRfO15irJKBRjBnrp9tSqN0jppklLIXKdtUcXlibcPQtuAeGUP2cPiz6bJd3ISuoYzLFNt4/fQYtLMw==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.9.1",
-        "@algolia/cache-common": "4.9.1",
-        "@algolia/cache-in-memory": "4.9.1",
-        "@algolia/client-account": "4.9.1",
-        "@algolia/client-analytics": "4.9.1",
-        "@algolia/client-common": "4.9.1",
-        "@algolia/client-recommendation": "4.9.1",
-        "@algolia/client-search": "4.9.1",
-        "@algolia/logger-common": "4.9.1",
-        "@algolia/logger-console": "4.9.1",
-        "@algolia/requester-browser-xhr": "4.9.1",
-        "@algolia/requester-common": "4.9.1",
-        "@algolia/requester-node-http": "4.9.1",
-        "@algolia/transporter": "4.9.1"
+        "@algolia/cache-browser-local-storage": "4.10.2",
+        "@algolia/cache-common": "4.10.2",
+        "@algolia/cache-in-memory": "4.10.2",
+        "@algolia/client-account": "4.10.2",
+        "@algolia/client-analytics": "4.10.2",
+        "@algolia/client-common": "4.10.2",
+        "@algolia/client-personalization": "4.10.2",
+        "@algolia/client-search": "4.10.2",
+        "@algolia/logger-common": "4.10.2",
+        "@algolia/logger-console": "4.10.2",
+        "@algolia/requester-browser-xhr": "4.10.2",
+        "@algolia/requester-common": "4.10.2",
+        "@algolia/requester-node-http": "4.10.2",
+        "@algolia/transporter": "4.10.2"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.4.4.tgz",
-      "integrity": "sha512-OjyVLjykaYKCMxxRMZNiwLp8CS310E0qAeIY2NaublcmLAh8/SL19+zYHp7XCLtMem2ZXwl3ywMiA32O9jszuw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.5.3.tgz",
+      "integrity": "sha512-DtSlOKAJ6TGkQD6u58g6/ABdMmHf3pAj6xVL5hJF+D4z9ldDRf/f5v6puNIxGOlJRwGVvFGyz34beYNqhLDUbQ==",
       "requires": {
         "events": "^1.1.1"
       },
@@ -3020,6 +3251,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        },
+        "normalize-url": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+          "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
         }
       }
     },
@@ -3215,18 +3451,18 @@
       }
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chrome-trace-event": {
@@ -3261,9 +3497,9 @@
       }
     },
     "clean-css": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.1.2.tgz",
-      "integrity": "sha512-QcaGg9OuMo+0Ds933yLOY+gHPWbxhxqF0HDexmToPf8pczvmvZGYzd+QqWp9/mkucAOKViI+dSFOqoZIvXbeBw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.1.3.tgz",
+      "integrity": "sha512-qGXzUCDpLwAlPx0kYeU4QXjzQIcIYZbJjD4FNm7NnSjoP0hYMVZhHOpUYJ6AwfkMX2cceLRq54MeCgHy/va1cA==",
       "requires": {
         "source-map": "~0.6.0"
       },
@@ -3398,9 +3634,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colord": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.0.1.tgz",
-      "integrity": "sha512-vm5YpaWamD0Ov6TSG0GGmUIwstrWcfKQV/h2CmbR7PbNu41+qdB5PW9lpzhjedrpm08uuYvcXi0Oel1RLZIJuA=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.1.0.tgz",
+      "integrity": "sha512-H5sDP9XDk2uP+x/xSGkgB9SEFc1bojdI5DMKU0jmSXQtml2GIe48dj1DcSS0e53QQAHn+JKqUXbGeGX24xWD7w=="
     },
     "colorette": {
       "version": "1.2.2",
@@ -3544,23 +3780,33 @@
       "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
     },
     "copy-webpack-plugin": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-8.1.1.tgz",
-      "integrity": "sha512-rYM2uzRxrLRpcyPqGceRBDpxxUV8vcDqIKxAUKfcnFpcrPxT5+XvhTxv7XLjo5AvEJFPdAE3zCogG2JVahqgSQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-9.0.1.tgz",
+      "integrity": "sha512-14gHKKdYIxF84jCEgPgYXCPpldbwpxxLbCmA7LReY7gvbaT555DgeBWBgBZM116tv/fO6RRJrsivBqRyRlukhw==",
       "requires": {
         "fast-glob": "^3.2.5",
-        "glob-parent": "^5.1.1",
+        "glob-parent": "^6.0.0",
         "globby": "^11.0.3",
         "normalize-path": "^3.0.0",
         "p-limit": "^3.1.0",
         "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1"
+        "serialize-javascript": "^6.0.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.0.tgz",
+          "integrity": "sha512-Hdd4287VEJcZXUwv1l8a+vXC1GjOQqXe+VS30w/ypihpcnu9M1n3xeYeJu5CBpeEQj2nAab2xxz28GuA3vp4Ww==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "core-js": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
-      "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ=="
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
     },
     "core-js-compat": {
       "version": "3.13.1",
@@ -3579,9 +3825,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
-      "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw=="
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.15.2.tgz",
+      "integrity": "sha512-D42L7RYh1J2grW8ttxoY1+17Y4wXZeKe7uyplAI3FkNQyI5OgBIAjUfFiTPfL1rs0qLpxaabITNbjKl1Sp82tA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3654,58 +3900,35 @@
       }
     },
     "css-minimizer-webpack-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-2.0.0.tgz",
-      "integrity": "sha512-cG/uc94727tx5pBNtb1Sd7gvUPzwmcQi1lkpfqTpdkuNq75hJCw7bIVsCNijLm4dhDcr1atvuysl2rZqOG8Txw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/css-minimizer-webpack-plugin/-/css-minimizer-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-B3I5e17RwvKPJwsxjjWcdgpU/zqylzK1bPVghcmpFHRL48DXiBgrtqz1BJsn68+t/zzaLp9kYAaEDvQ7GyanFQ==",
       "requires": {
-        "cssnano": "^5.0.0",
-        "jest-worker": "^26.3.0",
+        "cssnano": "^5.0.6",
+        "jest-worker": "^27.0.2",
         "p-limit": "^3.0.2",
-        "postcss": "^8.2.9",
+        "postcss": "^8.3.5",
         "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1",
+        "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "jest-worker": {
-          "version": "26.6.2",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
-          "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^7.0.0"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
     "css-select": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
-      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^4.0.0",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.4.3",
+        "css-what": "^5.0.0",
+        "domhandler": "^4.2.0",
+        "domutils": "^2.6.0",
         "nth-check": "^2.0.0"
       }
     },
@@ -3731,9 +3954,9 @@
       }
     },
     "css-what": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
-      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+      "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -3741,22 +3964,22 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.5.tgz",
-      "integrity": "sha512-L2VtPXnq6rmcMC9vkBOP131sZu3ccRQI27ejKZdmQiPDpUlFkUbpXHgKN+cibeO1U4PItxVZp1zTIn5dHsXoyg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.6.tgz",
+      "integrity": "sha512-NiaLH/7yqGksFGsFNvSRe2IV/qmEBAeDE64dYeD8OBrgp6lE8YoMeQJMtsv5ijo6MPyhuoOvFhI94reahBRDkw==",
       "requires": {
         "cosmiconfig": "^7.0.0",
-        "cssnano-preset-default": "^5.1.2",
+        "cssnano-preset-default": "^5.1.3",
         "is-resolvable": "^1.1.0"
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.1.2.tgz",
-      "integrity": "sha512-Joym8pdrIKqzASYvyTwJ9FpkmEcrYToWKWMGVFSggindrEDOpe+FgNpWhWcv6Z7GDZ4kCC3p7PE/oPSGTc8/kw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.1.3.tgz",
+      "integrity": "sha512-pS4+Q2Hoo/FevZs2JqA2BG8Vn5o5VeXgj+z6kGndKTq3RFYvlKeJ1ZPnLXo9zyYKwmSqWW0rWqtGxxmigIte0Q==",
       "requires": {
         "autoprefixer": "^10.2.0",
-        "cssnano-preset-default": "^5.1.2",
+        "cssnano-preset-default": "^5.1.3",
         "postcss-discard-unused": "^5.0.1",
         "postcss-merge-idents": "^5.0.1",
         "postcss-reduce-idents": "^5.0.1",
@@ -3764,9 +3987,9 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.2.tgz",
-      "integrity": "sha512-spilp8LRw0sacuxiN9A/dyyPr6G/WISKMBKcBD4NMoPV0ENx4DeuWvIIrSx9PII2nJIDCO3kywkqTPreECBVOg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.3.tgz",
+      "integrity": "sha512-qo9tX+t4yAAZ/yagVV3b+QBKeLklQbmgR3wI7mccrDcR+bEk9iHgZN1E7doX68y9ThznLya3RDmR+nc7l6/2WQ==",
       "requires": {
         "css-declaration-sorter": "^6.0.3",
         "cssnano-utils": "^2.0.1",
@@ -3790,9 +4013,9 @@
         "postcss-normalize-string": "^5.0.1",
         "postcss-normalize-timing-functions": "^5.0.1",
         "postcss-normalize-unicode": "^5.0.1",
-        "postcss-normalize-url": "^5.0.1",
+        "postcss-normalize-url": "^5.0.2",
         "postcss-normalize-whitespace": "^5.0.1",
-        "postcss-ordered-values": "^5.0.1",
+        "postcss-ordered-values": "^5.0.2",
         "postcss-reduce-initial": "^5.0.1",
         "postcss-reduce-transforms": "^5.0.1",
         "postcss-svgo": "^5.0.2",
@@ -4044,9 +4267,9 @@
       }
     },
     "domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -4172,9 +4395,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.1.tgz",
-      "integrity": "sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.6.0.tgz",
+      "integrity": "sha512-f8kcHX1ArhllUtb/wVSyvygoKCznIjnxhLxy7TCvIiMdT7fL4ZDTIKaadMe6eLvOXg6Wk02UeoFgUoZ2EKZZUA=="
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -4246,9 +4469,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eta": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.1.tgz",
-      "integrity": "sha512-H8npoci2J/7XiPnVcCVulBSPsTNGvGaINyMjQDU8AFqp9LGsEYS88g2CiU+d01Sg44WtX7o4nb8wUJ9vnI+tiA=="
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.2.tgz",
+      "integrity": "sha512-Z05sK2DRWAfBhG/2cwAOWuMoQIYaVYJCQrz2g2O/ekUjzWHNBv9L1pnblVDoDkKSb/AZ5tWZ0N/v4iaIU4+HjA=="
     },
     "etag": {
       "version": "1.8.1",
@@ -4499,16 +4722,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
-      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
+      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
+        "micromatch": "^4.0.4"
       }
     },
     "fast-json-stable-stringify": {
@@ -5012,9 +5234,9 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
-      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -5363,14 +5585,14 @@
       "integrity": "sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w=="
     },
     "html-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-rZsVvPXUYFyME0cuGkyOHfx9hmkFa4pWfxY/mdY38PsBEaVNsRoA+Id+8z6DBDgyv3zaw6XQszdF8HLwfQvcdQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.3.2.tgz",
+      "integrity": "sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==",
       "requires": {
         "@types/html-minifier-terser": "^5.0.0",
         "html-minifier-terser": "^5.0.1",
-        "lodash": "^4.17.20",
-        "pretty-error": "^2.1.1",
+        "lodash": "^4.17.21",
+        "pretty-error": "^3.0.4",
         "tapable": "^2.0.0"
       }
     },
@@ -5718,9 +5940,9 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infima": {
-      "version": "0.2.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.23.tgz",
-      "integrity": "sha512-V0RTjB1otjpH3E2asbydx3gz7ovdSJsuV7r9JTdBggqRilnelTJUcXxLawBQQKsjQi5qPcRTjxnlaV8xyyKhhw=="
+      "version": "0.2.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.26.tgz",
+      "integrity": "sha512-0/Dt+89mf8xW+9/hKGmynK+WOAsiy0QydVJL0qie6WK57yGIQv+SjJrhMybKndnmkZBQ+Vlt0tWPnTakx8X2Qw=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -6143,9 +6365,9 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "jest-worker": {
-      "version": "27.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.2.tgz",
-      "integrity": "sha512-EoBdilOTTyOgmHXtw/cPc+ZrCA0KJMrkXzkrPGNwLmnvvlN1nj7MPrxpT7m+otSv2e1TLaVffzDnE/LB14zJMg==",
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
+      "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -6627,9 +6849,9 @@
       }
     },
     "mini-css-extract-plugin": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.0.tgz",
-      "integrity": "sha512-nPFKI7NSy6uONUo9yn2hIfb9vyYvkFu95qki0e21DQ9uaqNKDP15DGpK0KnV6wDroWxPHtExrdEwx/yDQ8nVRw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+      "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0",
@@ -6827,9 +7049,9 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-url": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
-      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -7319,9 +7541,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
-      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
+      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
@@ -7553,12 +7775,12 @@
       }
     },
     "postcss-normalize-url": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.1.tgz",
-      "integrity": "sha512-hkbG0j58Z1M830/CJ73VsP7gvlG1yF+4y7Fd1w4tD2c7CaA2Psll+pQ6eQhth9y9EaqZSLzamff/D0MZBMbYSg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
+      "integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
       "requires": {
         "is-absolute-url": "^3.0.3",
-        "normalize-url": "^4.5.0",
+        "normalize-url": "^6.0.1",
         "postcss-value-parser": "^4.1.0"
       }
     },
@@ -7571,9 +7793,9 @@
       }
     },
     "postcss-ordered-values": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.1.tgz",
-      "integrity": "sha512-6mkCF5BQ25HvEcDfrMHCLLFHlraBSlOXFnQMHYhSpDO/5jSR1k8LdEXOkv+7+uzW6o6tBYea1Km0wQSRkPJkwA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
+      "integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
       "requires": {
         "cssnano-utils": "^2.0.1",
         "postcss-value-parser": "^4.1.0"
@@ -7615,9 +7837,9 @@
       }
     },
     "postcss-sort-media-queries": {
-      "version": "3.10.11",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.10.11.tgz",
-      "integrity": "sha512-78Ak5YSnalr+UTdZa2OCSNAxvEnHg3GRqWccStljJW7MqeU0cJtMA5OzaMmn+upM+iI5vykWzibVEAYaaAlSzw==",
+      "version": "3.11.12",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-3.11.12.tgz",
+      "integrity": "sha512-PNhEOWR/btZ0bNNRqqdW4TWxBPQ1mu2I6/Zpco80vBUDSyEjtduUAorY0Vm68rvDlGea3+sgEnQ36iQ1A/gG8Q==",
       "requires": {
         "sort-css-media-queries": "1.5.4"
       }
@@ -7657,12 +7879,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "pretty-error": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
-      "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-3.0.4.tgz",
+      "integrity": "sha512-ytLFLfv1So4AO1UkoBF6GXQgJRaKbiSiGFICaOPNwQ3CMvBvXpLRubeQWyPGnsbV/t9ml9qto6IeCsho0aEvwQ==",
       "requires": {
         "lodash": "^4.17.20",
-        "renderkid": "^2.0.4"
+        "renderkid": "^2.0.6"
       }
     },
     "pretty-time": {
@@ -7822,13 +8044,12 @@
       }
     },
     "react": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-base16-styling": {
@@ -7961,14 +8182,13 @@
       }
     },
     "react-dom": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.2"
       }
     },
     "react-error-overlay": {
@@ -8089,9 +8309,9 @@
       "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
     },
     "react-textarea-autosize": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.2.tgz",
-      "integrity": "sha512-JrMWVgQSaExQByP3ggI1eA8zF4mF0+ddVuX7acUeK2V7bmrpjVOY72vmLz2IXFJSAXoY3D80nEzrn0GWajWK3Q==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.0.0",
@@ -8109,9 +8329,9 @@
       }
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -8438,15 +8658,15 @@
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "renderkid": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.5.tgz",
-      "integrity": "sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
       "requires": {
-        "css-select": "^2.0.2",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.10.1",
-        "lodash": "^4.17.20",
-        "strip-ansi": "^3.0.0"
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8454,58 +8674,15 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
-        "css-select": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^3.2.1",
-            "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
-          }
-        },
-        "css-what": {
-          "version": "3.4.2",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
-          "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ=="
-        },
-        "dom-serializer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
           "requires": {
             "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
             "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-              "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "nth-check": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-          "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
-          "requires": {
-            "boolbase": "~1.0.0"
           }
         },
         "strip-ansi": {
@@ -8634,9 +8811,9 @@
       "integrity": "sha512-2sMcZO60tL9YDEFe24gqddg3hJ+xSmJFN8IExcQUxeHxQzydQrN6GHPL+yAWgzItXSI7es53hcZC9pJneuZDKA=="
     },
     "rtlcss": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.2.0.tgz",
-      "integrity": "sha512-nV3UmaTmA5TkP2dYOR16ULu6FkMOqZRbiXbFZnmWIN9coPfx3gin31VGOPV7vrVMPjNds7pCS2UYy0mwQUdFCQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.2.1.tgz",
+      "integrity": "sha512-S9bh35JXwPIhfun7nFu/HjlNrwELL5nvTJqA1suLfbnqY/mauIL5sBkrJNHziVppX9PA2rJ7NV82+RtzB71mJA==",
       "requires": {
         "chalk": "^4.1.0",
         "find-up": "^5.0.0",
@@ -8729,9 +8906,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -8835,9 +9012,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
-      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "requires": {
         "randombytes": "^2.1.0"
       }
@@ -9488,14 +9665,14 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "svgo": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.0.tgz",
-      "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
+      "integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
       "requires": {
         "@trysound/sax": "0.1.1",
         "chalk": "^4.1.0",
         "commander": "^7.1.0",
-        "css-select": "^3.1.2",
+        "css-select": "^4.1.3",
         "css-tree": "^1.1.2",
         "csso": "^4.2.0",
         "stable": "^0.1.8"
@@ -9514,9 +9691,9 @@
       "integrity": "sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw=="
     },
     "terser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.0.tgz",
-      "integrity": "sha512-HP5/9hp2UaZt5fYkuhNBR8YyRcT8juw8+uFbAme53iN9hblvKnLUTKkmwJG6ocWpIKf8UK4DoeWG4ty0J6S6/g==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
+      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -9536,14 +9713,14 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.3.tgz",
-      "integrity": "sha512-cxGbMqr6+A2hrIB5ehFIF+F/iST5ZOxvOmy9zih9ySbP1C2oEWQSOUS+2SNBTjzx5xLKO4xnod9eywdfq1Nb9A==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
+      "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
       "requires": {
         "jest-worker": "^27.0.2",
         "p-limit": "^3.1.0",
         "schema-utils": "^3.0.0",
-        "serialize-javascript": "^5.0.1",
+        "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
         "terser": "^5.7.0"
       },
@@ -9677,9 +9854,9 @@
       "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
     },
     "tslib": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
-      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "type-fest": {
       "version": "0.20.2",
@@ -10136,12 +10313,12 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
     "webpack": {
-      "version": "5.38.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.38.1.tgz",
-      "integrity": "sha512-OqRmYD1OJbHZph6RUMD93GcCZy4Z4wC0ele4FXyYF0J6AxO1vOSuIlU1hkS/lDlR9CDYBz64MZRmdbdnFFoT2g==",
+      "version": "5.41.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.41.1.tgz",
+      "integrity": "sha512-AJZIIsqJ/MVTmegEq9Tlw5mk5EHdGiJbDdz9qP15vmUH+oxI1FdWcL0E9EO8K/zKaRPWqEs7G/OPxq1P61u5Ug==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
-        "@types/estree": "^0.0.47",
+        "@types/estree": "^0.0.48",
         "@webassemblyjs/ast": "1.11.0",
         "@webassemblyjs/wasm-edit": "1.11.0",
         "@webassemblyjs/wasm-parser": "1.11.0",
@@ -10149,7 +10326,7 @@
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.8.0",
-        "es-module-lexer": "^0.4.0",
+        "es-module-lexer": "^0.6.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -10160,7 +10337,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.0.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.1.1",
+        "terser-webpack-plugin": "^5.1.3",
         "watchpack": "^2.2.0",
         "webpack-sources": "^2.3.0"
       }
@@ -10591,9 +10768,9 @@
       }
     },
     "webpack-merge": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.7.3.tgz",
-      "integrity": "sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
+      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
       "requires": {
         "clone-deep": "^4.0.1",
         "wildcard": "^2.0.0"
@@ -10741,9 +10918,9 @@
       }
     },
     "ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow=="
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,15 @@
     "serve": "docusaurus serve"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.ff31de0ff",
-    "@docusaurus/preset-classic": "^2.0.0-beta.ff31de0ff",
-    "@mdx-js/react": "^1.5.8",
+    "@docusaurus/core": "2.0.0-beta.2",
+    "@docusaurus/preset-classic": "2.0.0-beta.2",
+    "@mdx-js/react": "^1.6.21",
+    "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "file-loader": "^6.2.0",
+    "prism-react-renderer": "^1.2.1",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "yarn": "^1.22.10"
   },
   "browserslist": {

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -4,7 +4,7 @@ Chialisp is a powerful and secure LISP-like language for encumbering and releasi
 This website is a consolidated place to learn about Chialisp, CLVM and the conditions language.
 
 Here's a sample:
-```
+```chialisp
 (mod (password new_puzhash amount)
   (defconstant CREATE_COIN 51)
 

--- a/src/theme/prism-chialisp.js
+++ b/src/theme/prism-chialisp.js
@@ -1,0 +1,188 @@
+(function (Prism) {
+	// Functions to construct regular expressions
+	// simple form
+	// e.g. (interactive ... or (interactive)
+	function simple_form(name) {
+		return RegExp('(\\()' + name + '(?=[\\s\\)])');
+	}
+	// booleans and numbers
+	function primitive(pattern) {
+		return RegExp('([\\s([])' + pattern + '(?=[\\s)])');
+	}
+
+	// Patterns in regular expressions
+
+	// Symbol name. See https://www.gnu.org/software/emacs/manual/html_node/elisp/Symbol-Type.html
+	// & and : are excluded as they are usually used for special purposes
+	var symbol = '[-+*/_~!@$%^=<>{}\\w]+';
+	// symbol starting with & used in function arguments
+	var marker = '&' + symbol;
+	// Open parenthesis for look-behind
+	var par = '(\\()';
+	var endpar = '(?=\\))';
+	// End the pattern with look-ahead space
+	var space = '(?=\\s)';
+
+	var language = {
+		comment: /;.*/,
+		string: {
+			pattern: /"(?:[^"\\]|\\.)*"/,
+			greedy: true,
+			inside: {
+				argument: /[-A-Z]+(?=[.,\s])/,
+				symbol: RegExp('`' + symbol + "'")
+			}
+		},
+		keyword: [
+			{
+				pattern: RegExp(
+					par +
+						'(?:(?:lexical-)?let\\*?|(?:cl-)?if|defconstant|i|include)' +
+						space
+				),
+				lookbehind: true
+			},
+			{
+				pattern: RegExp(
+					par + '(?:sha256|x|a|=|concat|\\+|\\-|\\/|\\*|logand|logior|logxor|lognot|ash|lsh|substr|strlen|sha256|point_add|pubkey_for_exp)(?=\\s+|\\))'
+				),
+				lookbehind: true,
+        alias: 'builtin',
+			},
+      {
+				pattern: RegExp(
+					par + '(?:q[q]*|unquote)(?=\\s+|\\))'
+				),
+				lookbehind: true,
+        alias: 'quotes',
+			},
+      {
+				pattern: RegExp(
+					par + '(?:f|r|list|c|l)' + space
+				),
+				lookbehind: true,
+        alias: 'listop',
+			},
+		],
+		boolean: {
+			pattern: primitive('\\(\\)'),
+			lookbehind: true
+		},
+		number: {
+			pattern: RegExp('([\\s([])' + '[-+]?\\d+(?:\\.\\d*)?'),
+			lookbehind: true
+		},
+    hexadecimal: {
+      pattern: /(?<![^0])x[0-9a-zA-Z]+/,
+      lookbehind: true
+    },
+    brun: /(\$ )*(brun|run|opd|opc)/,
+		defun: {
+			pattern: RegExp(
+				par +
+					'(?:cl-)?(?:defun\\*?|defmacro|defun-inline)\\s+' +
+					symbol +
+					'\\s+\\([\\s\\S]*?\\)'
+			),
+			lookbehind: true,
+			inside: {
+				keyword: /^(?:cl-)?def\S+/,
+        // identifier: RegExp(symbol),
+				// See below, this property needs to be defined later so that it can
+				// reference the language object.
+				arguments: null,
+				function: {
+					pattern: RegExp('(^\\s)' + symbol),
+					lookbehind: true
+				},
+				punctuation: /[()]/
+			}
+		},
+    mod: {
+			pattern: RegExp(
+				par +
+					'(?:cl-)?(?:mod)' +
+					'\\s+\\([\\s\\S]*?\\)'
+			),
+			lookbehind: true,
+			inside: {
+				keyword: /^mod/,
+				// See below, this property needs to be defined later so that it can
+				// reference the language object.
+				arguments: null,
+				function: {
+					pattern: RegExp('(^\\s)'),
+					lookbehind: true
+				},
+				punctuation: /[()]/
+			}
+		},
+		car: {
+			pattern: RegExp(par + symbol + space),
+			lookbehind: true
+		},
+		punctuation: [
+			// open paren, brackets, and close paren
+			/(?:['`,]?\(|[)\[\]])/,
+			// cons
+			{
+				pattern: /(\s)\.(?=\s)/,
+				lookbehind: true
+			},
+		]
+	};
+
+	var arg = {
+		'lisp-marker': RegExp(marker),
+		rest: {
+			argument: {
+				pattern: RegExp(symbol),
+				alias: 'variable'
+			},
+			varform: {
+				pattern: RegExp(par + symbol + '\\s+\\S[\\s\\S]*' + endpar),
+				lookbehind: true,
+				inside: {
+					string: language.string,
+					boolean: language.boolean,
+					number: language.number,
+					symbol: language.symbol,
+					punctuation: /[()]/
+				}
+			}
+		}
+	};
+
+	var forms = '\\S+(?:\\s+\\S+)*';
+
+	var arglist = {
+		pattern: RegExp(par + '[\\s\\S]*' + endpar),
+		lookbehind: true,
+		inside: {
+			'rest-vars': {
+				pattern: RegExp('&(?:rest|body)\\s+' + forms),
+				inside: arg
+			},
+			'other-marker-vars': {
+				pattern: RegExp('&(?:optional|aux)\\s+' + forms),
+				inside: arg
+			},
+			keys: {
+				pattern: RegExp('&key\\s+' + forms + '(?:\\s+&allow-other-keys)?'),
+				inside: arg
+			},
+			argument: {
+				pattern: RegExp(symbol),
+				alias: 'variable'
+			},
+			punctuation: /[()]/
+		}
+	};
+
+	language['defun'].inside.arguments = Prism.util.clone(arglist);
+	language['defun'].inside.arguments.inside.sublist = Prism.util.clone(arglist);
+  language['mod'].inside.arguments = Prism.util.clone(arglist);
+	language['mod'].inside.arguments.inside.sublist = Prism.util.clone(arglist);
+
+	Prism.languages.chialisp = language;
+}(Prism));

--- a/src/theme/prism-dark-theme-chialisp.js
+++ b/src/theme/prism-dark-theme-chialisp.js
@@ -24,7 +24,8 @@ var theme = {
   }, {
     types: ["number","hexadecimal","string","boolean"], //numbers and hexes must be the same color
     style: {
-      color: "rgb(255, 184, 108)"
+      color: "rgb(255, 184, 108)",
+      fontWeight: "normal",
     }
   }, {
     types: ["punctuation", "symbol"],
@@ -39,7 +40,8 @@ var theme = {
   }, {
     types: ["comment"],
     style: {
-      color: "rgb(98, 114, 164)"
+      color: "rgb(98, 114, 164)",
+      fontWeight: "normal",
     }
   }, {
     types: ["function","car"],

--- a/src/theme/prism-dark-theme-chialisp.js
+++ b/src/theme/prism-dark-theme-chialisp.js
@@ -1,0 +1,51 @@
+// Original: https://github.com/dracula/visual-studio-code
+// Converted automatically using ./tools/themeFromVsCode
+var theme = {
+  plain: {
+    color: "#F8F8F2",
+    backgroundColor: "#282A36"
+  },
+  styles: [{
+    types: ["keyword"],
+    style: {
+      color: "rgb(189, 147, 249)"
+    }
+  }, {
+    types: ["listop","class-name","quotes"],
+    style: {
+      color: "rgb(80, 250, 123)"
+    }
+  }, {
+    types: ["builtin"],
+    style: {
+      color: "rgb(5, 227, 223)"
+    }
+  }, {
+    types: ["number","hexadecimal","string","boolean"], //numbers and hexes must be the same color
+    style: {
+      color: "rgb(255, 184, 108)"
+    }
+  }, {
+    types: ["punctuation", "symbol"],
+    style: {
+      color: "rgb(248, 248, 242)"
+    }
+  }, {
+    types: ["variable"],
+    style: {
+      fontStyle: "italic"
+    }
+  }, {
+    types: ["comment"],
+    style: {
+      color: "rgb(98, 114, 164)"
+    }
+  }, {
+    types: ["function","car","brun"],
+    style: {
+      color: "rgb(241, 250, 140)"
+    }
+  }]
+};
+
+module.exports = theme;

--- a/src/theme/prism-include-languages.js
+++ b/src/theme/prism-include-languages.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+import siteConfig from '@generated/docusaurus.config';
+
+const prismIncludeLanguages = (PrismObject) => {
+  if (ExecutionEnvironment.canUseDOM) {
+    const {
+      themeConfig: {prism: {additionalLanguages = []} = {}},
+    } = siteConfig;
+    window.Prism = PrismObject;
+    additionalLanguages.forEach((lang) => {
+      require(`prismjs/components/prism-${lang}`); // eslint-disable-line
+    });
+
+    require("./prism-chialisp");
+
+    delete window.Prism;
+  }
+};
+
+export default prismIncludeLanguages;

--- a/src/theme/prism-light-theme-chialisp.js
+++ b/src/theme/prism-light-theme-chialisp.js
@@ -24,7 +24,8 @@ var theme = {
   }, {
     types: ["number","hexadecimal","string","boolean"], //numbers and hexes must be the same color
     style: {
-      color: "#B35C00"
+      color: "#B35C00",
+      fontWeight: "normal",
     }
   }, {
     types: ["punctuation", "symbol"],
@@ -39,7 +40,8 @@ var theme = {
   }, {
     types: ["comment"],
     style: {
-      color: "#73737D"
+      color: "#73737D",
+      fontWeight: "normal",
     }
   }, {
     types: ["function","car"],

--- a/src/theme/prism-light-theme-chialisp.js
+++ b/src/theme/prism-light-theme-chialisp.js
@@ -2,34 +2,34 @@
 // Converted automatically using ./tools/themeFromVsCode
 var theme = {
   plain: {
-    color: "#F8F8F2",
-    backgroundColor: "#282A36",
-    fontWeight: "bold",
+    color: "#383a42",
+    backgroundColor: "#fafafa",
+    fontWeight: "bold"
   },
   styles: [{
     types: ["keyword"],
     style: {
-      color: "rgb(189, 147, 249)"
+      color: "#990096",
     }
   }, {
     types: ["listop","class-name","quotes"],
     style: {
-      color: "rgb(80, 250, 123)"
+      color: "#006100"
     }
   }, {
     types: ["builtin"],
     style: {
-      color: "rgb(5, 227, 223)"
+      color: "#127EAF"
     }
   }, {
     types: ["number","hexadecimal","string","boolean"], //numbers and hexes must be the same color
     style: {
-      color: "rgb(255, 184, 108)"
+      color: "#B35C00"
     }
   }, {
     types: ["punctuation", "symbol"],
     style: {
-      color: "rgb(248, 248, 242)"
+      color: "#383a42"
     }
   }, {
     types: ["variable"],
@@ -39,12 +39,12 @@ var theme = {
   }, {
     types: ["comment"],
     style: {
-      color: "rgb(98, 114, 164)"
+      color: "#73737D"
     }
   }, {
     types: ["function","car"],
     style: {
-      color: "rgb(241, 250, 140)"
+      color: "#0045DB"
     }
   }]
 };


### PR DESCRIPTION
To review this PR, make sure to pull the branch and run the development server so you can see the highlighting in action.  I'm very open to comments on what operators should be what colors.

Also important to note that the dark mode theme is being run for all of the code blocks, even in the light mode.  I couldn't find a light theme that looked good.  Lisp does not particularly like to be highlighted.

And it's in the title but I also had to bump some dependencies as well as add a new one for this to work.  