### PR TITLE
Safari compatibility fix

### DIFF
--- a/src/theme/prism-chialisp.js
+++ b/src/theme/prism-chialisp.js
@@ -73,7 +73,7 @@
 			lookbehind: true
 		},
     hexadecimal: {
-      pattern: /(?<![^0])x[0-9a-zA-Z]+/,
+      pattern: /x[0-9a-zA-Z]+/,
       lookbehind: true
     },
     brun: /(\$ )*(brun|run|opd|opc)/,


### PR DESCRIPTION
This doesn't actually change anything apparently except that js doesn't break on Safari anymore.