### PR TITLE
fix: corrected deprecated home id console error

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -1,6 +1,7 @@
 ---
 id: basics
 title: 1 - CLVM Basics
+slug: /
 sidebar_label: 1 - CLVM Basics
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,8 @@ module.exports = {
       {
         docs: {
           // It is recommended to set document id as docs home page (`docs/` path).
-          homePageId: 'basics',
+          path: 'docs',
+          routeBasePath: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl:


### PR DESCRIPTION
@roybotbot This should resolve the errors on console. Pull it down and let me know if it removes it for you as well. I didn't have any issues with these changes around the site.