### PR TITLE
Make the capitalisation consistent

### DIFF
--- a/docs/basics.md
+++ b/docs/basics.md
@@ -5,7 +5,7 @@ slug: /
 sidebar_label: 1 - CLVM Basics
 ---
 
-CLVM is the compiled, minimal version of ChiaLisp that is used by the Chia network.
+CLVM is the compiled, minimal version of Chialisp that is used by the Chia network.
 Chialisp compiles into CLVM so it's important to understand how it works.
 The full set of operators is documented [here](/docs/ref/clvm).
 

--- a/docs/coins_spends_and_wallets.md
+++ b/docs/coins_spends_and_wallets.md
@@ -5,7 +5,7 @@ title: 2 - Coins, Spends and Wallets
 
 This guide assumes knowledge of [the basics of CLVM](/docs/) so if you haven't read that page, please do so before reading this.
 
-This section of the guide will cover evaluating a program inside a program, how ChiaLisp relates to transactions and coins on the Chia network, and cover some techniques to create smart transactions using ChiaLisp.
+This section of the guide will cover evaluating a program inside a program, how Chialisp relates to transactions and coins on the Chia network, and cover some techniques to create smart transactions using Chialisp.
 If there are any terms that you aren't sure of, be sure to check the [glossary](/docs/glossary).
 
 ## Puzzles and Solutions
@@ -66,7 +66,7 @@ By the end of the next section of the guide, hopefully it should be clear.
 
 ## Puzzles and Solutions in Practice
 
-So far we have covered ChiaLisp programs that will evaluate to some result.
+So far we have covered Chialisp programs that will evaluate to some result.
 Remember the first part represents a puzzle which is committed to locking up a coin, and the second part is a solution anybody can submit:
 
 ```chialisp
@@ -204,7 +204,7 @@ Conversely lets consider a coin locked up with the following puzzle:
 1
 ```
 
-This example may look a little weird, because most ChiaLisp programs are lists, and this is just an atom, but it is still a valid program.
+This example may look a little weird, because most Chialisp programs are lists, and this is just an atom, but it is still a valid program.
 This puzzle simply returns the entire solution.
 You can think about this in terms of power and control.
 The person that locked the coin up has given all the power to the person who provides the solution.
@@ -218,7 +218,7 @@ $ brun '1' '((51 0xf00dbabe 75) (51 0xfadeddab 15) (51 0x1234abcd 10))'
 ```
 
 In this situation, not only can anybody spend the coin, they can spend it however they like!
-This balance of power determines a lot of how puzzles are designed in ChiaLisp.
+This balance of power determines a lot of how puzzles are designed in Chialisp.
 
 For example, let's create a puzzle that lets the spender choose the output, but with one stipulation.
 
@@ -350,5 +350,5 @@ $ brun '(c (c (q . 50) (c (q . 0xfadedcab) (c (sha256 2) ()))) (a 5 11))' '("hel
 Coin ownership refers to the concept of creating a coin with a puzzle that means it can only be spent when signed by the private key of the coin's "owner".
 The goal of wallet software is to generate, interpret and manage these kinds of coins and puzzles.
 
-The next part of this guide will go further in depth in ChiaLisp, and cover how to write more complex puzzles.
+The next part of this guide will go further in depth in Chialisp, and cover how to write more complex puzzles.
 If any of the material in this part of the guide has got you confused, try returning to it after the next part.

--- a/docs/deeper_into_clvm.md
+++ b/docs/deeper_into_clvm.md
@@ -5,13 +5,13 @@ title: 3 - Deeper into CLVM
 
 This guide assumes knowledge of [the basics of CLVM](/docs/) so if you haven't read that, please do so before reading this.
 
-This section of the guide will cover how ChiaLisp relates to transactions and coins on the Chia network.
+This section of the guide will cover how Chialisp relates to transactions and coins on the Chia network.
 If there are any terms that you aren't sure of, be sure to check the [glossary](/docs/glossary).
 
-## Lazy Evaluation in ChiaLisp
+## Lazy Evaluation in Chialisp
 
 As we've seen in earlier sections, programs are often structured around `(i A B C)` to control flow.
-ChiaLisp evaluates programs as trees, where the leaves are evaluated first.
+Chialisp evaluates programs as trees, where the leaves are evaluated first.
 This can cause unexpected problems if you are not aware of it.
 Consider the following program which uses `x` which immediately halts and throws an error if it is evaluated.
 
@@ -20,7 +20,7 @@ $ brun '(i (q . 1) (q . 100) (x (q . "still being evaluated")))'
 FAIL: clvm raise (0x7374696c6c206265696e67206576616c7561746564)
 ```
 
-This is because ChiaLisp evaluates both of the leaves even though it will only follow the path of one.
+This is because Chialisp evaluates both of the leaves even though it will only follow the path of one.
 
 To get around this we can use the following design pattern to replace (i A B C).
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,11 +1,11 @@
 ---
 id: faq
-title: ChiaLisp and CLVM FAQ
-sidebar_label: ChiaLisp and CLVM FAQ
+title: Chialisp and CLVM FAQ
+sidebar_label: Chialisp and CLVM FAQ
 ---
 * [Why is my number being evaluated to `()`, a.k.a. `nil`?](#q-why-is-my-number-being-evaluated-to--aka-nil)
 * [Is it possible to store data or maintain state in smart coins?](#q-is-it-possible-to-store-data-or-maintain-state-in-smart-coins)
-* [What is the difference between ChiaLisp, CLVM bytecode, CLVM assembly and the Conditions Language?](#q-what-is-the-difference-between-chialisp-clvm-bytecode-clvm-assembly-and-the-conditions-language)
+* [What is the difference between Chialisp, CLVM bytecode, CLVM assembly and the Conditions Language?](#q-what-is-the-difference-between-chialisp-clvm-bytecode-clvm-assembly-and-the-conditions-language)
 * [What is a CAT?](#q-what-is-a-cat)
 * [What is a TAIL?](#q-what-is-a-tail)
 * [How can I receive some tokens?](#q-how-can-i-receive-some-tokens)
@@ -19,22 +19,22 @@ ____
 
 **A:** In clvm (the `brun` command), integers are evaluated as references to arguments in the argument tree.
 If no argument tree is given on the command line, the default is an empty argument tree. When an argument is not found, `nil` is returned.
-In ChiaLisp (the `run` command), integers are compiled to quoted atoms, which will give you the value you expected.
+In Chialisp (the `run` command), integers are compiled to quoted atoms, which will give you the value you expected.
 ____
 
 ### Q: Is it possible to store data or maintain state in smart coins?
 
 **A:** Yes, but probably not how you are thinking.
-Quite deliberately the ChiaLisp environment is designed so that state is stored exclusively in coins.
+Quite deliberately the Chialisp environment is designed so that state is stored exclusively in coins.
 Remember Chia uses smart coins, not smart contracts. This leads to a different kind of design to smart contracts.
 A common design pattern in Chia smart coins is that they will recreate themselves with the same puzzle but with some "state" changed.
 ___
 
-### Q: What is the difference between ChiaLisp, CLVM bytecode, CLVM assembly and the Conditions Language?
+### Q: What is the difference between Chialisp, CLVM bytecode, CLVM assembly and the Conditions Language?
 
-**A:** ChiaLisp is the higher level language which can be compiled into the lower level language called CLVM.
+**A:** Chialisp is the higher level language which can be compiled into the lower level language called CLVM.
 
-CLVM Assembly is the lower level language that ChiaLisp is compiled to.
+CLVM Assembly is the lower level language that Chialisp is compiled to.
 
 CLVM Bytecode is the serialized form of CLVM Assembly.
 

--- a/docs/ref/clvm.md
+++ b/docs/ref/clvm.md
@@ -4,14 +4,14 @@ title: CLVM Reference Manual
 sidebar_label: CLVM Reference
 ---
 
-The clvm is a small, tightly defined VM that defines the semantics of CLVM programs run during Chia blockchain validation. It serves as a target language for higher level languages, especially ChiaLisp.
+The clvm is a small, tightly defined VM that defines the semantics of CLVM programs run during Chia blockchain validation. It serves as a target language for higher level languages, especially Chialisp.
 
 
 ## Definitions
 
 * **CLVM Assembly** - The textual representation of a CLVM program.
 * **CLVM Bytecode** - The serialized form of a CLVM program.
-* **ChiaLisp** - A higher-level language, built on top of CLVM.
+* **Chialisp** - A higher-level language, built on top of CLVM.
 * **CLVM Object** - The underlying data type in the CLVM. An atom or a cons pair.
 * **Atom** - The datatype for values in the CLVM. Atoms are immutable byte arrays. Atoms are untyped and are used to encode all strings, integers, and keys. The only things in the CLVM which are not atoms are cons pairs. Atom properties are length, and the bytes in the atom.
 * **cons pair** - An immutable ordered pair of references to other CLVM objects. One of two data types in the CLVM. The syntax for a cons pair is a dotted pair. Also called `cons cell` or `cons box`.
@@ -564,7 +564,7 @@ At the moment, `softfork` always returns `0` (aka `()` or nil), and takes `cost`
 
 At first glance, it seems pretty useless since it doesn't do anything, and just wastes cost doing it.
 
-The idea is, after a soft fork, the meaning of the arguments may change. In fact, we can hide completely new dialects of ChiaLisp inside here, that has new operators that calculate new things.
+The idea is, after a soft fork, the meaning of the arguments may change. In fact, we can hide completely new dialects of Chialisp inside here, that has new operators that calculate new things.
 
 For example, suppose we want to add secp256k1 operators like `+s` for adding two points on this ECDSA curve for bitcoin compatibility. We can't just do this in vanilla clvm because that would make a program `(+s p1 p2)` return different values before and after the soft fork. So instead we hide it under `softfork`.
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -59,7 +59,7 @@ The natural interoperability that Chialisp provides is also relevant because it 
 
 ## Developer Documentation
 
-- [ChiaLisp Compiler Repository](https://github.com/Chia-Network/clvm)
+- [Chialisp Compiler Repository](https://github.com/Chia-Network/clvm)
 - [A video introduction to developing in Chialisp](https://chialisp.com/docs/tutorials/developing_applications)
 - [clvm_tools for developing in Chialisp](https://github.com/Chia-Network/clvm_tools)
 - [CLVM Basics](/docs/)


### PR DESCRIPTION
Fixing a few inconsistent uses of "ChiaLisp" instead of "Chialisp"