### PR TITLE
Update costs

### DIFF
--- a/docs/ref/clvm.md
+++ b/docs/ref/clvm.md
@@ -823,7 +823,7 @@ To recap, before the transaction:
 * Bob had zero coins
 * The total value was 1.946839958396 XCH
 
-After the trasaction:
+After the transaction:
 * Alice had one coin worth 0.936839958396 XCH
 * Bob had one coin worth 1.01 XCH
 * The total value was 1.946839958396 XCH (same as before the transaction)

--- a/docs/ref/clvm.md
+++ b/docs/ref/clvm.md
@@ -742,7 +742,223 @@ cost = 806
 820080
 ```
 
-Now that you know _what_ the cost of each CLVM operator is, as well as _how_ to hand-calculate costs, we'll discuss _why_ we decided to structure costs in this manner. It all begins with the minimum spec machine for farming, the humble Raspberry Pi 4.
+## Evaluating cost for a typical transaction
+
+Now let's look at a real-world example of calculating cost. The _standard_ transaction is one that adds and removes one or more vanilla XCH coins from the coin set. While it is possible to both add and remove exactly one coin in a standard transaction, a more _typical_ transaction would involve adding and removing two coins, giving the transaction two inputs and two outputs.
+
+This would happen if Alice spent two coins to send money to Bob, and received one coin back as change.
+
+### Obtaining transaction info from a wallet
+
+Let's look at an example of a transaction where Alice sent money to Bob and received change, from the perspective of Alice's computer. First, we'll run `get_transactions` to obtain the transaction ID:
+
+```bash
+(venv) chia-blockchain $ chia wallet get_transactions
+Transaction cd4e915dc8fd6eb932b5e1be67088eb9af48a560a6ddbc55c53ee44eaf191ee0
+Status: Confirmed
+Amount sent: 1.01 XCH
+To address: xch1989s7f4dn43963gsdqus7z6ydm7upuqzfae4ftts7rm80k4848csewg085
+Created at: 2022-03-20 21:03:09
+```
+
+Next, we'll get more info by running `get_transaction`, entering the ID we just obtained:
+
+```bash
+(venv) chia-blockchain $ chia wallet get_transaction -tx
+cd4e915dc8fd6eb932b5e1be67088eb9af48a560a6ddbc55c53ee44eaf191ee0 -v
+{'additions': [{ 'amount': 1010000000000,
+                 'parent_coin_info': '0x484ed352cd7e7e396bdbee72302e40653c2d880bd134d29f75f07ffffe4c7a0f',
+                 'puzzle_hash': '0x29cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1'
+               },
+               { 'amount': 936839958396,
+                 'parent_coin_info': '0x484ed352cd7e7e396bdbee72302e40653c2d880bd134d29f75f07ffffe4c7a0f',
+                 'puzzle_hash': '0xf56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fef'
+               }],
+               'amount': 1010000000000,
+               'confirmed': True,
+               'confirmed_at_height': 1720943,
+               'created_at_time': 1647781389,
+               'fee_amount': 0,
+               'memos': [],
+               'name': '0xcd4e915dc8fd6eb932b5e1be67088eb9af48a560a6ddbc55c53ee44eaf191ee0',
+'removals':   [{ 'amount': 946839958396,
+                 'parent_coin_info': '0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e',
+                 'puzzle_hash': '0xe415c314693b27c0cb949c27cb244a8ed9def528346f37491393fdd49e24bcd5'
+               },
+               { 'amount': 1000000000000,
+                 'parent_coin_info': '0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e',
+                'puzzle_hash': '0xd8af3cb1130f6d7e4011c6fa85779c0cfddb1a594cdd170d1dfc8aeb5f3c93fe'
+               }],
+'spend_bundle': { 'aggregated_signature': '0xa35c58c6687e79a91e2c409451e620dc26f286637be916910d02253fa0fb401a77d0f3c2b0ff72565fae5c9e66affbe70833f7bbae6b2c3508404f6058ec82d94f9738d23a4b23748d97d71e532a7d7c6390f21fe82dc5f1c0c75d90150d952f',
+                  'coin_spends': [{
+                     'coin': {
+                        'amount': 946839958396,
+                        'parent_coin_info': '0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e',
+                        'puzzle_hash': '0xe415c314693b27c0cb949c27cb244a8ed9def528346f37491393fdd49e24bcd5'
+                     },
+                        'puzzle_reveal': '0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b09496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010ff018080',
+                        'solution': '0xff80ffff01ffff33ffa029cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1ff8600eb28b0f40080ffff33ffa0f56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fefff8600da20034f7c80ffff3cffa048c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d8080ff8080'
+                  },
+                  {
+                     'coin': {
+                        'amount': 1000000000000,
+                        'parent_coin_info': '0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e',
+                        'puzzle_hash': '0xd8af3cb1130f6d7e4011c6fa85779c0cfddb1a594cdd170d1dfc8aeb5f3c93fe'
+                     },
+                        'puzzle_reveal': '0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14ff018080',
+                        'solution': '0xff80ffff01ffff3dffa023f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c428080ff8080'
+                  }]},
+}
+```
+
+The `additions` and `removals` sections contain two coins apiece. Before the transaction, Alice had two coins in her wallet, one worth 1 XCH, and one worth 0.946839958396 XCH. The amount sent was 1.01 XCH, which was greater than the value of either of Alice's coins. The wallet therefore automatically selected both coins to be sent, for a total of 1.946839958396 XCH. A new coin worth 0.936839958396 XCH was created in Alice's wallet as "change". 
+
+To recap, before the transaction:
+* Alice had two coins, worth 1 XCH and 0.946839958396 XCH
+* Bob had zero coins
+* The total value was 1.946839958396 XCH
+
+After the trasaction:
+* Alice had one coin worth 0.936839958396 XCH
+* Bob had one coin worth 1.01 XCH
+* The total value was 1.946839958396 XCH (same as before the transaction)
+
+Back to the original question: what was the CLVM cost of this transaction? One way to find out is by creating a spend bundle based on the output of the `get_transaction` command, and inspecting it using `cdv`.
+
+  > NOTE: You'll need to run `pip install chia-dev-tools` in order to use the `cdv` command.
+
+```bash 
+(venv) chia-blockchain $ cdv inspect spendbundles spend.json -ec
+...
+Cost: 17187295
+```
+
+The cost was 17,187,295. The minimum transaction fee is 5 mojos per cost (anything less than this will be treated as 0). In this case, the minimum fee is `5 * 17,187,295 = 85,936,475 mojos`. For this specific transaction, including a fee greater than this number would cause it jump ahead of the zero-fee transactions in the mempool.
+
+In general, if you don't know the exact cost of a transaction before it is run, it's a good idea to round the fee up to 100 million mojos.
+
+### Obtaining transaction info using RPC
+
+To obtain the same info using RPC commands, get the record of the coin you want to examine:
+
+```bash
+(venv) chia-blockchain $ cdv rpc coinrecords --by id 0x484ed352cd7e7e396bdbee72302e40653c2d880bd134d29f75f07ffffe4c7a0f
+[
+    {
+        "coin": {
+            "amount": 946839958396,
+            "parent_coin_info": "0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e",
+            "puzzle_hash": "0xe415c314693b27c0cb949c27cb244a8ed9def528346f37491393fdd49e24bcd5"
+        },
+        "coinbase": false,
+        "confirmed_block_index": 1720835,
+        "spent": true,
+        "spent_block_index": 1720943,
+        "timestamp": 1647780998
+    }
+]
+```
+
+This coin was spent in block 1720943. Using this info, we can get the original puzzle and solution used in the coin spend, in serialized form:
+
+```bash
+(venv) chia-blockchain $ cdv rpc blockspends -id 484ed352cd7e7e396bdbee72302e40653c2d880bd134d29f75f07ffffe4c7a0f -h 1720943
+{
+    "coin": {
+        "amount": 946839958396,
+        "parent_coin_info": "0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e",
+        "puzzle_hash": "0xe415c314693b27c0cb949c27cb244a8ed9def528346f37491393fdd49e24bcd5"
+    },
+    "puzzle_reveal": "0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b09496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010ff018080",
+    "solution": "0xff80ffff01ffff33ffa029cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1ff8600eb28b0f40080ffff33ffa0f56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fefff8600da20034f7c80ffff3cffa048c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d8080ff8080"
+}
+```
+
+Next, use the `opd` command to deserialize the puzzle and solution to human-readable clvm:
+
+```bash
+(venv) chia-blockchain $ opd ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b09496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010ff018080
+(a (q 2 (q 2 (i 11 (q 2 (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 ()))))))) (q 2 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 ()))) ()))) (a 23 47))) 1) (c (q 50 2 (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 ()))) (a 6 (c 2 (c 13 ())))) (q 11 (q . 1) 5)) 1) 1)) (c (q . 0x9496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010) 1))
+```
+
+```bash
+(venv) chia-blockchain $ opd ff80ffff01ffff33ffa029cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1ff8600eb28b0f40080ffff33ffa0f56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fefff8600da20034f7c80ffff3cffa048c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d8080ff8080
+(() (q (51 0x29cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1 0x00eb28b0f400) (51 0xf56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fef 0x00da20034f7c) (60 0x48c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d)) ())
+```
+
+To obtain the cost of this program, use `brun -c`:
+
+```bash
+(venv) chia-blockchain $ brun -c '(a (q 2 (q 2 (i 11 (q 2 (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 ()))))))) (q 2 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 ()))) ()))) (a 23 47))) 1) (c (q 50 2 (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 ()))) (a 6 (c 2 (c 13 ())))) (q 11 (q . 1) 5)) 1) 1)) (c (q . 0x9496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010) 1))' '(() (q (51 0x29cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1 0x00eb28b0f400) (51 0xf56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fef 0x00da20034f7c) (60 0x48c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d)) ())'
+cost = 39652
+((50 0x9496e8abd4a5b09f10b71e43b779f7ed8d5c1c92e3c5a6b70cd78bc2fb32347cc5fdca3f6acafb143f185029cd422010 0x87f20f182aa0b488027d678fd1cdb63f9fb583347cbf2744d2e7f5ae5ab49102) (51 0x29cb0f26ad9d625d451068390f0b446efdc0f0024f7354ad70f0f677daa7a9f1 0x00eb28b0f400) (51 0xf56f5af041272572fe528e794c364fbe2be444ab77de62a1796772804a4c9fef 0x00da20034f7c) (60 0x48c2db108c24bf3192913b6cd5bca66688a9b2fc0e1821e306f7b01848a7b24d))
+```
+
+The cost of this program was 39,652. However, there are two important things to note here:
+1. This cost does not include the CLVM conditions, specifically condition 50 (AGG_SIG_ME) and 51 (CREATE_COIN)
+2. Another coin was spent in the same transaction, which is not included here
+
+Let's run the same commands to figure out the cost of the other coin spend:
+
+```bash
+(venv) chia-blockchain $ cdv rpc coinrecords --by id 0x45174eedbd162f2baeb37d7360c14727782d8f58519f878665efcdaef62a407a
+[
+    {
+        "coin": {
+            "amount": 1000000000000,
+            "parent_coin_info": "0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e",
+            "puzzle_hash": "0xd8af3cb1130f6d7e4011c6fa85779c0cfddb1a594cdd170d1dfc8aeb5f3c93fe"
+        },
+        "coinbase": false,
+        "confirmed_block_index": 1720835,
+        "spent": true,
+        "spent_block_index": 1720943,
+        "timestamp": 1647780998
+    }
+]
+```
+
+```bash
+(venv) chia-blockchain $ cdv rpc blockspends -id 45174eedbd162f2baeb37d7360c14727782d8f58519f878665efcdaef62a407a -h 1720943
+{
+    "coin": {
+        "amount": 1000000000000,
+        "parent_coin_info": "0x98706c3a489574a9f32f339662f339b7ba3c9dce1da4feb301432aa60216635e",
+        "puzzle_hash": "0xd8af3cb1130f6d7e4011c6fa85779c0cfddb1a594cdd170d1dfc8aeb5f3c93fe"
+    },
+    "puzzle_reveal": "0xff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14ff018080",
+    "solution": "0xff80ffff01ffff3dffa023f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c428080ff8080"
+}
+```
+
+```bash
+(venv) chia-blockchain $ opd ff02ffff01ff02ffff01ff02ffff03ff0bffff01ff02ffff03ffff09ff05ffff1dff0bffff1effff0bff0bffff02ff06ffff04ff02ffff04ff17ff8080808080808080ffff01ff02ff17ff2f80ffff01ff088080ff0180ffff01ff04ffff04ff04ffff04ff05ffff04ffff02ff06ffff04ff02ffff04ff17ff80808080ff80808080ffff02ff17ff2f808080ff0180ffff04ffff01ff32ff02ffff03ffff07ff0580ffff01ff0bffff0102ffff02ff06ffff04ff02ffff04ff09ff80808080ffff02ff06ffff04ff02ffff04ff0dff8080808080ffff01ff0bffff0101ff058080ff0180ff018080ffff04ffff01b0848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14ff018080
+(a (q 2 (q 2 (i 11 (q 2 (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 ()))))))) (q 2 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 ()))) ()))) (a 23 47))) 1) (c (q 50 2 (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 ()))) (a 6 (c 2 (c 13 ())))) (q 11 (q . 1) 5)) 1) 1)) (c (q . 0x848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14) 1))
+```
+
+```bash
+(venv) chia-blockchain $ opd ff80ffff01ffff3dffa023f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c428080ff8080
+(() (q (61 0x23f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c42)) ())
+```
+
+```bash
+(venv) chia-blockchain $ brun -c '(a (q 2 (q 2 (i 11 (q 2 (i (= 5 (point_add 11 (pubkey_for_exp (sha256 11 (a 6 (c 2 (c 23 ()))))))) (q 2 23 47) (q 8)) 1) (q 4 (c 4 (c 5 (c (a 6 (c 2 (c 23 ()))) ()))) (a 23 47))) 1) (c (q 50 2 (i (l 5) (q 11 (q . 2) (a 6 (c 2 (c 9 ()))) (a 6 (c 2 (c 13 ())))) (q 11 (q . 1) 5)) 1) 1)) (c (q . 0x848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14) 1))' '(() (q (61 0x23f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c42)) ())'
+cost = 15032
+((50 0x848f09f98800442737684dd76071f25a0bd100b51e727aabafeddb062dbc3d2b3ac64bc87f084a6d16e4e89e1417de14 0x03db13c4e422e5eea98463c02b2c15994b620e0a45aa2db6f7785d3ba28f46cf) (61 0x23f61666150d2a467ee7b81a77954c93255d65c0c43108f1bb14ac420fd59c42))
+```
+
+The cost for this coin spend (without the AGG_SIG_ME condition) was 15,032. Let's add up the costs to get the total cost for this transaction:
+* First coin
+    * CLVM: 39652
+    * AGG_SIG_ME: 1200000
+    * CREATE_COIN 1: 1800000
+    * CREATE_COIN 2: 1800000 
+* Second coin
+    * CLVM: 15032
+    * AGG_SIG_ME: 1200000
+* Total: 6,054,684
+
+Now that you know _what_ the cost of each CLVM operator is, as well as _how_ to calculate costs, we'll discuss _why_ we decided to structure costs in this manner. It all begins with the minimum spec machine for farming, the humble Raspberry Pi 4.
 
 ## Minimum spec machine for farming
 


### PR DESCRIPTION
I added a new section showing how to calculate the cost of an actual transaction with two inputs and two outputs. It uses two techniques:
1. `cdv inspect spendbundles`: This is a quicker way to estimate costs, but also less accurate due to the command creating a simulated block
2. Using RPC to get the original CLVM program and adding costs manually. This is more time-consuming, but also more accurate.

This PR needs a review as it might need to be tweaked a bit.