### PR TITLE
Update dated info and links- spend coin w/ RPC tutorial

### DIFF
--- a/docs/tutorials/coin_spend_rpc.md
+++ b/docs/tutorials/coin_spend_rpc.md
@@ -9,11 +9,14 @@ This tutorial teaches you how to spend a coin with any puzzle using RPC calls. W
 ## Get your coin's info (amount, puzzle hash & parent info)
 RPC call for spending a coin requires you to specify which coin you are spending. For unique identification, you need the coin's amount, puzzle hash, and parent info. Those three pieces of information are also enough to calculate the coin's ID.
 
-### Using Chia explorer (by puzzle hash/receive address)
-If you know the puzzle hash or receive address of the coin you are looking for, you can [search for it using Chia explorer](https://www.chiaexplorer.com/blockchain/search). Chia explorer cannot search using puzzle hash, so if you have a puzzle hash, you first need to convert it to receive address using [Chia explorer's tool](https://www.chiaexplorer.com/tools/address-puzzlehash-converter).
-Remember that receive addresses are just encoded puzzle hashes and will still refer to the puzzle you are looking for.
+If you know the puzzle hash or receive address of the coin you are looking for, you can use [Chia Dev Tools](https://github.com/Chia-Network/chia-dev-tools) to get the coin's information. 
 
-When you search for a receive address, you'll see all coins locked by the corresponding puzzle. Select the one you want to spend. That will get you the coin's amount, puzzle hash, and parent info.
+**Example for the password-locked coin:**
+```bash
+cdv rpc coinrecords --by puzzlehash 4843c869bba5f65aa1e806cd372dae5668ca3b69640d067e86837ca96b324e71
+```
+
+Click through this [tutorial](https://chialisp.com/docs/tutorials/tools_and_setup) to learn more about tools and setup. 
 
 ## Get serialized puzzle and solution
 The next thing you need to know to spend the coin is the coin's puzzle and solution. Puzzles and solutions are provided in a serialized format, so we need to get that for each. The puzzle has to be compiled to low-level Chialisp and is serialized as normal.
@@ -46,7 +49,7 @@ opc -H '(a (q 2 (i (= (sha256 5) (q . 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c
 ff02ffff01ff02ffff03ffff09ffff0bff0580ffff01a02cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982480ffff01ff04ffff04ff02ffff04ff0bffff04ff17ff80808080ff8080ffff01ff088080ff0180ffff04ffff0133ff018080
 ```
 
-### Serialization using [Quexington's Chialisp Dev Utility](https://github.com/Quexington/chialisp_dev_utility)
+### Serialization using [Chia Dev Tools](https://github.com/Chia-Network/chia-dev-tools)
 
 Follow repository's README to set up a new project and serialize puzzle.
 
@@ -57,7 +60,7 @@ In short: paste your compiled puzzle/solution to your work file and call `chiali
 Paste your puzzle in the text area and click **Compile**. The serialized result will be displayed in the **Serialized** section.
 
 ## Spend a coin with RPC call
-To spend your coin, you only need to call RPC (broadcast transaction example) with values specific to your spend.
+To spend your coin, you only need to call [push_tx](https://docs.chia.net/docs/12rpcs/full_node_api#push_tx) RPC (broadcast transaction example) with values specific to your spend.
 
 ```bash
 curl --insecure --cert ~/.chia/mainnet/config/ssl/full_node/private_full_node.crt --key ~/.chia/mainnet/config/ssl/full_node/private_full_node.key -d '{        "spend_bundle": {
@@ -69,16 +72,16 @@ curl --insecure --cert ~/.chia/mainnet/config/ssl/full_node/private_full_node.cr
                         "parent_coin_info": "0xccd5bb71183532bff220ba46c268991a00000000000000000000000000004082",
                         "puzzle_hash": "0x4843c869bba5f65aa1e806cd372dae5668ca3b69640d067e86837ca96b324e71"
                     },
-                    "puzzle_reveal": "ff02ffff01ff02ffff03ffff09ffff0bff0580ffff01a02cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982480ffff01ff04ffff04ff02ffff04ff0bffff04ff17ff80808080ff8080ffff01ff088080ff0180ffff04ffff0133ff018080 ",
-                    "solution": "ff8568656c6c6fffa05f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675ff0280"
+                    "puzzle_reveal": "0xff02ffff01ff02ffff03ffff09ffff0bff0580ffff01a02cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b982480ffff01ff04ffff04ff02ffff04ff0bffff04ff17ff80808080ff8080ffff01ff088080ff0180ffff04ffff0133ff018080 ",
+                    "solution": "0xff8568656c6c6fffa05f5767744f91c1c326d927a63d9b34fa7035c10e3eb838c44e3afe127c1b7675ff0280"
                 }
             ]
         }}' -H "Content-Type: application/json" -X POST https://localhost:8555/push_tx
 ```
 
-The `spend_bundle` object contains an `aggregated_signature`, which we can later assert in the puzzle, and `coin_spends`: a list of objects for all of the coins we are spending. If `aggregated_signature` is not necessary for your puzzle, use 0xc followed by 191 zeros (as in the example above). However, it's worth noting that a puzzle that doesn't use a signature is usually unsafe and should be used only for testing purposes.
+The [`spend_bundle`](https://docs.chia.net/docs/04coin-set-model/spend_bundles) object contains an `aggregated_signature`, which we can later assert in the puzzle, and `coin_spends`: a list of objects for all of the coins we are spending. If `aggregated_signature` is not necessary for your puzzle, use 0xc followed by 191 zeros (as in the example above). However, it's worth noting that a puzzle that doesn't use a signature is usually unsafe and should be used only for testing purposes.
 
-The `coin_solution` contains information about the `coin` it is spending (`amount`, `parent_coin_info`, and  `puzzle_hash`). It also includes a serialized puzzle as a `puzzle_reveal` and serialized `solution`.
+The `coin_solution` contains information about the `coin` it is spending (`amount`, `parent_coin_info`, and  `puzzle_hash`). It also includes a serialized puzzle as a `puzzle_reveal` and serialized `solution`. Note: if this is your time constructing a spend bundle, the `puzzle_hash` is the puzzlehash of the receive address that you wish to send to `coin` to.
 
 If you fill in all your information correctly and send this request, your coin will be spent according to its provided solution, and the response `{"status": "SUCCESS", "success": true}` should be returned from the RPC call.
 


### PR DESCRIPTION
- Replaced explorer with cdv rpc coinrecords; the current version of exploring doesn't provide detailed coin information. 
- Updated references of "Quexington's Chialisp Dev Utility" to "Chia Dev Tools" 
- Added reference to tutorial for tools and setups 
- Added a short note and explanation of 'puzzle_hash' (receive address) for constructing the spend bundle, as the readers mostly are constructing it for the first time. 
- Fixed missing hex prefix 0x in the spend bundle.