### PR TITLE
Update setting_up_testnet.md

### DIFF
--- a/docs/getting_started/setting_up_testnet.md
+++ b/docs/getting_started/setting_up_testnet.md
@@ -20,7 +20,7 @@ If you are using Windows, we recommend PowerShell, and you may need to replace f
 5.  Run `chia init` to setup and configure Chia.
 6.  Run `chia keys generate` to prepare the wallet keys.
 7.  Run `chia configure -t true` to use the Testnet.
-8.  Download the [Testnet database](https://download.chia.net/testnet10/blockchain_v2_testnet10.sqlite.gz) and place it in the `~/.chia/testnet10/db` folder.
+8.  Download the [Testnet database](https://download.chia.net/testnet10/blockchain_v2_testnet10.sqlite.gz) and place it in the `~/.chia/testnet10/db` folder. *Unzip the database before continuing.*
 9.  Finally, run `chia start node` to start the full node.
 
 ## Faucet


### PR DESCRIPTION
A minor note about decompressing the database before continuing. I tried to match the same language, with brevity, as on the code-repository wiki. 

It is also stated in the wiki here: https://github.com/Chia-Network/chia-blockchain/wiki/How-to-Connect-to-the-Testnet#step-5-download-the-official-testnet-db-optional


> What ends up happening if the db isn't unzip'd? 
The node will start from height 0 on the testnet; as it should. 

> Why am I proposing this change?
Save someone from guessing if chia will decompress it automatically if they spent the time to download 20Gb.