### PR TITLE
Fix typo on NFTs page

### DIFF
--- a/docs/primitives/nfts.md
+++ b/docs/primitives/nfts.md
@@ -243,7 +243,7 @@ This is the source code of the default NFT metadata updater, which can also be f
 
 </details>
 
-## Decision Decisions
+## Design Decisions
 
 #### Multiple separate forms of data {#data}
 


### PR DESCRIPTION
Fixed a typo in the Primitives/NFTs page. 

The header was "**Decision Decisions**"
Assuming it was supposed to be "**Design Decisions**"