### PR TITLE
fix `ASSERT_MY_PUZZLEHASH` typo

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -539,7 +539,7 @@ The following parameters are expected:
 
 ---
 
-### 72 `ASSERT_MY_PUZZLE_HASH` {#assert-my-puzzle-hash}
+### 72 `ASSERT_MY_PUZZLEHASH` {#assert-my-puzzlehash}
 
 Format: `(72 puzzle_hash)`
 


### PR DESCRIPTION
It'd be `ASSERT_MY_PUZZLEHASH` according to [condition codes](https://github.com/Chia-Network/chia-blockchain/blob/main/chia/wallet/puzzles/condition_codes.clib#L45).