### PR TITLE
Add min-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary

Adds `min-release-age=1` to `.npmrc`, which tells npm to only resolve package versions published more than 1 day ago. Most malicious package versions are detected and yanked within hours, so a 24-hour delay filters out smash-and-grab supply chain attacks.

Requires npm >= 11.10.0 (ships with Node.js >= 24.14.1). Older npm versions silently ignore the setting.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change; it may affect dependency resolution in CI/dev environments using older npm versions or when needing very recent releases.
> 
> **Overview**
> Adds `min-release-age=1` to `.npmrc` so npm will prefer dependencies that are at least one day old, reducing exposure to newly-published malicious versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323b63cb1d781540d9f05af22f57edc22cc8b83c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->