### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -766,6 +766,7 @@ jobs:
           fi
 
       - name: Run Cursor analysis
+        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single workflow `if` condition; no application or security logic changes, though non-org repos will no longer get Cursor-generated analysis in PR comments.
> 
> **Overview**
> Limits **Cursor CLI dependency analysis** in the Dependency Cursor Review workflow so it only runs when `github.repository_owner` is **Chia-Network**, matching the org guard already used on the separate Dependency Review workflow.
> 
> Upstream malware scanning, usage hints, artifact upload, and PR commenting still run; only the step that installs prompts, calls the Cursor `agent`, and writes `cursor_output.json` is skipped elsewhere. On skipped runs, the comment step falls back to its existing “no Cursor output” message while still posting malware scan results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8e7f6eab4f18cceb32cb60a38ba5e7cd8de7e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->