### PR TITLE
Update ingress annotations and add className

### DIFF
--- a/k8s/review.yaml.j2
+++ b/k8s/review.yaml.j2
@@ -7,8 +7,9 @@ service:
 
 ingress:
   enabled: true
+  className: contour
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/force-ssl-redirect: "true"
   hosts:
     - host: {{ REVIEW_SLUG }}.chialisp-web.chia.net
       paths:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small review-only Kubernetes ingress template tweak with no application or auth logic changes.
> 
> **Overview**
> Review environment ingress now explicitly uses the **Contour** ingress controller via `className: contour`.
> 
> The SSL redirect annotation is switched from `ingress.kubernetes.io/ssl-redirect` to **`ingress.kubernetes.io/force-ssl-redirect`**, matching Contour’s expected annotation for mandatory HTTPS redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21336584dd93a7179e34c4b6d43e31a49ed092ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->