### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/dependency-cursor-review.yml
+++ b/.github/workflows/dependency-cursor-review.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   dependency-review:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'))
+    if: github.repository_owner == 'Chia-Network' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]')))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -766,7 +766,6 @@ jobs:
           fi
 
       - name: Run Cursor analysis
-        if: github.repository_owner == 'Chia-Network'
         timeout-minutes: 10
         env:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only guard changes; no application runtime or secret-handling logic is modified beyond when the workflow runs.
> 
> **Overview**
> **Dependency Cursor Review** now only runs in the **Chia-Network** org, matching other managed workflows like dependency review.
> 
> The job `if` adds `github.repository_owner == 'Chia-Network'` alongside the existing Dependabot/Renovate and `workflow_dispatch` triggers. The duplicate `if: github.repository_owner == 'Chia-Network'` on **Run Cursor analysis** is removed so org scoping lives at the job level and the whole job is skipped on forks or other owners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d299c2852bd606a4d08b972fd6467cee62a7fc75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->